### PR TITLE
Use apiology/circleci-python Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ commands:
 jobs:
   test:
     docker:
-      - image: apiology/circleci:latest
+      - image: apiology/circleci-python:latest
     steps:
       - unless:
           condition:

--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -102,7 +102,7 @@ commands:
 jobs:
   test:
     docker:
-      - image: apiology/circleci:latest
+      - image: apiology/circleci-python:latest
     steps:
       - unless:
           condition:


### PR DESCRIPTION
The original apiology/circleci only has the latest Python version now, and we build all versions.