### PR TITLE
Use apiology/circleci-python:latest for cookiecutter builds

### DIFF
--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -132,7 +132,7 @@ jobs:
     resource_class: large
   overcommit:
     docker:
-      - image: apiology/circleci:latest
+      - image: apiology/circleci-python:latest
     steps:
       - when:
           condition:


### PR DESCRIPTION
We're installing all active Pythons with ./fix.sh as we're testing
them all, so let's make sure builds can cache that installation.