### PR TITLE
Do 'circleci follow' after 'git push'

### DIFF
--- a/{{cookiecutter.project_slug}}/hooks/post_gen_project.py
+++ b/{{cookiecutter.project_slug}}/hooks/post_gen_project.py
@@ -50,6 +50,6 @@ if __name__ == '__main__':
                                    '.',
                                    '{% raw %}{{ cookiecutter.github_username }}/{% endraw %}'
                                    '{% raw %}{{ cookiecutter.project_slug }}{% endraw %}'])
-            subprocess.check_call(['circleci', 'follow'])
             subprocess.check_call(['git', 'push'])
+            subprocess.check_call(['circleci', 'follow'])
             subprocess.check_call(['git', 'branch', '--set-upstream-to=origin/main', 'main'])


### PR DESCRIPTION
CircleCI seems to now require objects to exist in repo first;
otherwise you get 'Error: Could not follow project'