### PR TITLE
codecov isn't allowed to fail on generated projects

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -77,9 +77,6 @@ coverage: test report-coverage ## check code coverage
 report-coverage: test ## Report summary of coverage to stdout, and generate HTML, XML coverage report
 
 report-coverage-to-codecov: report-coverage ## use codecov.io for PR-scoped code coverage reports
-	@curl -Os https://uploader.codecov.io/latest/linux/codecov
-	@chmod +x codecov
-	@./codecov --file coverage.xml --nonZero
 
 cicoverage: report-coverage-to-codecov ## check code coverage, then report to codecov
 

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/Makefile
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/Makefile
@@ -66,7 +66,7 @@ report-coverage: test ## Report summary of coverage to stdout, and generate HTML
 report-coverage-to-codecov: report-coverage ## use codecov.io for PR-scoped code coverage reports
 	@curl -Os https://uploader.codecov.io/latest/linux/codecov
 	@chmod +x codecov
-	@./codecov --file coverage.xml
+	@./codecov --file coverage.xml --nonZero
 
 cicoverage: report-coverage-to-codecov ## check code coverage, then report to codecov
 


### PR DESCRIPTION
It shouldn't run on cookiecutter projects, however, since we don't
have code to test per se (I guess maybe the hooks?  idk)