### PR TITLE
Port language-agnostic boilerplate from checkoff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
             bin/overcommit --sign pre-push
 
 
-            bin/overcommit --run
+            bundle exec overcommit --diff
   tox:
     description: "Run tox"
     parameters:

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# there's a lot of .sh in the build machinery; this can overwhelm
+# smaller projects and confuse GitHub's detection of majority project
+# type (GitHub uses the linguist library)
+#
+# https://dev.to/katkelly/changing-your-repo-s-language-in-github-5gjo
+*.sh linguist-detectable=false

--- a/fix.sh
+++ b/fix.sh
@@ -182,20 +182,17 @@ ensure_bundle() {
   # if bundler_version is still empty
   if [ -z "${bundler_version}" ]
   then
-      gem install bundler
+      gem install bundler:2.5.5
       bundler_version=$(bundle --version | cut -d ' ' -f 3)
   fi
   echo "Bundler version: ${bundler_version}"
   bundler_version_major=$(cut -d. -f1 <<< "${bundler_version}")
   bundler_version_minor=$(cut -d. -f2 <<< "${bundler_version}")
   bundler_version_patch=$(cut -d. -f3 <<< "${bundler_version}")
-  # Version 2.1 of bundler seems to have some issues with nokogiri:
   #
-  # https://app.asana.com/0/1107901397356088/1199504270687298
-
-  # Version <2.2.22 of bundler isn't compatible with Ruby 3.3:
+  # Version 2.5.5 fixed an issue in 2.2.22 with the 'bump' gem:
   #
-  # https://stackoverflow.com/questions/70800753/rails-calling-didyoumeanspell-checkers-mergeerror-name-spell-checker-h
+  # https://app.circleci.com/pipelines/github/apiology/checkoff/1281/workflows/f667f909-c3fc-4ae2-8593-dde2b588a7a7/jobs/2491
 
   # Version <2.2.9 doesn't seem to handle git branches during 'bundle lock' in some situations
   #

--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
             bin/overcommit --sign pre-push
 
 
-            bin/overcommit --run
+            bundle exec overcommit --diff
   tox:
     description: "Run tox"
     parameters:

--- a/{{cookiecutter.project_slug}}/.gitattributes
+++ b/{{cookiecutter.project_slug}}/.gitattributes
@@ -1,0 +1,6 @@
+# there's a lot of .sh in the build machinery; this can overwhelm
+# smaller projects and confuse GitHub's detection of majority project
+# type (GitHub uses the linguist library)
+#
+# https://dev.to/katkelly/changing-your-repo-s-language-in-github-5gjo
+*.sh linguist-detectable=false

--- a/{{cookiecutter.project_slug}}/fix.sh
+++ b/{{cookiecutter.project_slug}}/fix.sh
@@ -182,20 +182,17 @@ ensure_bundle() {
   # if bundler_version is still empty
   if [ -z "${bundler_version}" ]
   then
-      gem install bundler
+      gem install bundler:2.5.5
       bundler_version=$(bundle --version | cut -d ' ' -f 3)
   fi
   echo "Bundler version: ${bundler_version}"
   bundler_version_major=$(cut -d. -f1 <<< "${bundler_version}")
   bundler_version_minor=$(cut -d. -f2 <<< "${bundler_version}")
   bundler_version_patch=$(cut -d. -f3 <<< "${bundler_version}")
-  # Version 2.1 of bundler seems to have some issues with nokogiri:
   #
-  # https://app.asana.com/0/1107901397356088/1199504270687298
-
-  # Version <2.2.22 of bundler isn't compatible with Ruby 3.3:
+  # Version 2.5.5 fixed an issue in 2.2.22 with the 'bump' gem:
   #
-  # https://stackoverflow.com/questions/70800753/rails-calling-didyoumeanspell-checkers-mergeerror-name-spell-checker-h
+  # https://app.circleci.com/pipelines/github/apiology/checkoff/1281/workflows/f667f909-c3fc-4ae2-8593-dde2b588a7a7/jobs/2491
 
   # Version <2.2.9 doesn't seem to handle git branches during 'bundle lock' in some situations
   #


### PR DESCRIPTION
## Summary

- Add `.gitattributes` so `*.sh` files (including `fix.sh`) are not counted heavily by GitHub linguist
- Pin `bundler:2.5.5` in `fix.sh` when no bundler version is detected, with updated comment from checkoff
- Use `bundle exec overcommit --diff` instead of `bin/overcommit --run` in the CircleCI quality job

Changes applied at repo root and in the nested `{{cookiecutter.project_slug}}/` slug template.

Ruby/Sorbet/undercover-specific checkoff changes were intentionally excluded (see plan).

## Test plan

- [x] `circleci config validate .circleci/config.yml`
- [x] Pre-commit hooks pass on commit
- [x] Bake test generates `.gitattributes` and runs `fix.sh` successfully
- [ ] CircleCI green on PR

Made with [Cursor](https://cursor.com)