### PR TITLE
Fix weekly CI on main

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2025 Audrey Roy Greenfeld, Vince Broz and individual contributors.
+Copyright (c) 2013-2026 Audrey Roy Greenfeld, Vince Broz and individual contributors.
 
 All rights reserved.
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,6 +7,7 @@ lxml==5.3.0
 pip==23.3.1
 pytest-cookies==0.6.1
 pytest==8.3.4
+setuptools==75.3.4
 tox==4.6.0
 watchdog==3.0.0
 yamllint==1.35.1

--- a/{{cookiecutter.project_slug}}/LICENSE
+++ b/{{cookiecutter.project_slug}}/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2025 Audrey Roy Greenfeld, Vince Broz and individual contributors.
+Copyright (c) 2013-2026 Audrey Roy Greenfeld, Vince Broz and individual contributors.
 
 All rights reserved.
 

--- a/{{cookiecutter.project_slug}}/requirements_dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements_dev.txt
@@ -7,6 +7,7 @@ lxml==5.3.0
 pip==23.3.1
 pytest-cookies==0.7.0
 pytest==8.3.4
+setuptools==75.3.4
 tox==4.6.0
 watchdog==3.0.0
 yamllint==1.35.1


### PR DESCRIPTION
## Summary
- Pin `setuptools==75.3.4` in dev requirements so `flake8-import-order` can load `pkg_resources` after tox upgrades pip (fixes weekly CircleCI `build` job on `main`).
- Update LICENSE copyright end year to 2026 in the repo and cookiecutter template so `test_bake_and_run_build` passes in the current year.

## Test plan
- [ ] CircleCI `build` workflow on this branch
- [ ] Weekly workflow after merge (or re-run scheduled build on `main`)
- [x] Local: `tox -e py38,py39,quality,py310`
- [x] Local: `make citypecheck citypecoverage`


Made with [Cursor](https://cursor.com)