### PR TITLE
Run fix.sh on clone and worktree checkout

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -87,6 +87,10 @@ PreCommit:
 PostCheckout:
   BundleInstall:
     enabled: true
+  CustomScript:
+    enabled: true
+    requires_files: false
+    required_executable: './bin/git-post-checkout-fix'
 
 PostCommit:
   BundleInstall:

--- a/bin/git-post-checkout-fix
+++ b/bin/git-post-checkout-fix
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# post-checkout: prev_head new_head branch_checkout
+# Git uses a null ref for the previous HEAD on clone and git worktree add.
+NULL_REF='0000000000000000000000000000000000000000'
+
+prev_head="${1:-}"
+branch_checkout="${3:-}"
+
+if [ "${branch_checkout}" != '1' ] || [ "${prev_head}" != "${NULL_REF}" ]; then
+  exit 0
+fi
+
+exec ./fix.sh


### PR DESCRIPTION
## Summary

- Add `bin/git-post-checkout-fix`, an Overcommit `post-checkout` wrapper that runs `./fix.sh` only when Git reports a null previous HEAD (clone or `git worktree add`), not on ordinary branch checkouts.
- Enable the wrapper in `.overcommit.yml` under `PostCheckout`.

## Test plan

- [ ] `git checkout main` on an existing clone does **not** run `fix.sh` (hook exits immediately).
- [ ] `git worktree add ../test-worktree` runs `fix.sh` in the new worktree.
- [ ] After pulling, run `bin/overcommit --sign` and `bin/overcommit --sign post-checkout` before committing (see `.cursor/rules/overcommit-signing.mdc`).


Made with [Cursor](https://cursor.com)