### PR TITLE
Propagate post-checkout fix.sh hook to all template tiers

### DIFF
--- a/.cursor/rules/template-hierarchy.mdc
+++ b/.cursor/rules/template-hierarchy.mdc
@@ -23,11 +23,23 @@ This repo is the **meta** cookiecutter (`cookiecutter-cookiecutter`). It bakes *
 |----------------|-----------|-----------------------------------|--------------------|
 | `overcommit-signing.mdc` | Yes | Yes | Yes |
 | `template-hierarchy.mdc` | Yes (this file) | Yes (tier-specific) | Yes (tier-specific) |
+| `fix.sh`, `bin/git-*` hooks, shared `.overcommit.yml` bootstrap | Yes | Yes | Yes |
 | Boilerplate sync skills/docs | No — in baked child path | Yes | No |
 | Language-specific hooks (RuboCop, etc.) | No | Yes | Maybe (framework-only → nested) |
 | Pytest bake-project tips in `DEVELOPMENT.md` | Yes (meta tests) | Yes | No — not every baked project uses Python |
 | `.envrc` `PATH_add` | Only paths that exist at that tier | Same | Same |
 
 **Rule of thumb:** place each file at the **narrowest** tier that still applies to every repo that tier generates. Too specific for this tree → nested or a child cookiecutter; too general to live only here → ancestor.
+
+## Propagate across tiers (agent checklist)
+
+This repo nests **three** template trees (meta root → `{{cookiecutter.project_slug}}/` → nested `{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/`). Many boilerplate files exist at **more than one** path (`fix.sh`, `.overcommit.yml`, `bin/git-commit-validate`, `bin/git-post-checkout-fix`, etc.).
+
+When adding or changing such a file:
+
+1. **List tiers** — run `find` or search for the basename under the repo (ignore `.git/`).
+2. **Apply at every tier** where the file already exists, unless the change is intentionally tier-specific.
+3. **Keep paths parallel** — same relative path and hook wiring at each tier (e.g. `PostCheckout` + `bin/git-post-checkout-fix` next to existing `bin/git-push-validate`).
+4. **If unsure** whether a change belongs at one tier or all three, **ask the user** before opening a PR.
 
 When editing the inner template, read `{{cookiecutter.project_slug}}/.cursor/rules/template-hierarchy.mdc` and `docs/SYNCING_BOILERPLATE.md`.

--- a/{{cookiecutter.project_slug}}/.cursor/rules/template-hierarchy.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/template-hierarchy.mdc
@@ -16,11 +16,16 @@ Cookiecutter templates in this family stack **general → specific** (meta → l
 |----------------|---------------|---------------|----------------------------------------------------------------|
 | `overcommit-signing.mdc` | Yes | Yes | Yes |
 | `template-hierarchy.mdc` | Yes | Yes (this file) | Yes (project tier) |
+| `fix.sh`, `bin/git-*` hooks, shared `.overcommit.yml` bootstrap | Yes | Yes | Yes |
 | Boilerplate sync skill + `SYNCING_BOILERPLATE.md` | Baked path only | **Yes** | No |
 | Language hooks (RuboCop, etc.) | No | **Yes** | Framework-only → nested |
 | Pytest bake tips in `DEVELOPMENT.md` | Meta repo | **Yes** if this template uses pytest | No — not every baked project uses Python |
 
 Place each artifact at the **narrowest** tier that still applies to every repo that tier generates.
+
+## Propagate across tiers (agent checklist)
+
+The meta repo and this tree each maintain parallel copies of cross-language boilerplate (`fix.sh`, `.overcommit.yml`, `bin/git-*`, etc.). When you change one copy, **search for the same basename** under the meta repo and update **every tier** where it exists (meta root, this directory, nested `{% raw %}{{cookiecutter.project_slug}}/{% endraw %}`), unless the edit is tier-specific. If unsure, **ask the user** before submitting a PR. See the meta rule `template-hierarchy.mdc` for the full three-tier map.
 
 Interpret every sync or edit against three directions:
 

--- a/{{cookiecutter.project_slug}}/.overcommit.yml
+++ b/{{cookiecutter.project_slug}}/.overcommit.yml
@@ -87,6 +87,10 @@ PreCommit:
 PostCheckout:
   BundleInstall:
     enabled: true
+  CustomScript:
+    enabled: true
+    requires_files: false
+    required_executable: 'bin/git-post-checkout-fix'
 
 PostCommit:
   BundleInstall:

--- a/{{cookiecutter.project_slug}}/bin/git-post-checkout-fix
+++ b/{{cookiecutter.project_slug}}/bin/git-post-checkout-fix
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# post-checkout: prev_head new_head branch_checkout
+# Git uses a null ref for the previous HEAD on clone and git worktree add.
+NULL_REF='0000000000000000000000000000000000000000'
+
+prev_head="${1:-}"
+branch_checkout="${3:-}"
+
+if [ "${branch_checkout}" != '1' ] || [ "${prev_head}" != "${NULL_REF}" ]; then
+  exit 0
+fi
+
+exec ./fix.sh

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.cursor/rules/template-hierarchy.mdc
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.cursor/rules/template-hierarchy.mdc
@@ -20,6 +20,10 @@ alwaysApply: false
 - If a reference repo is more specific than this template (e.g. Rails app vs Ruby repo), treat extra config as **out of scope** for this cookiecutter (or a different child template).
 - Do **not** add cookiecutter-family sync skills, `SYNCING_BOILERPLATE.md`, or pytest bake tips unless this project template is Python-specific by design.
 
+## Propagate across tiers (agent checklist)
+
+Cross-language boilerplate (`fix.sh`, `.overcommit.yml`, `bin/git-*`, etc.) is mirrored at **meta root**, the language/tool template, and **this** nested project template. When editing one copy, check whether the same file exists upstream or downstream and keep all applicable tiers in sync. If unsure whether a change belongs here only or at every tier, **ask the user**. See ancestor `template-hierarchy.mdc` rules (meta and `{{ cookiecutter.project_slug }}/`).
+
 ## Referenced paths must exist here
 
 When porting `.envrc`, Makefile paths, or hook `include`s — if the path does not exist in this tree, it likely belongs in an **ancestor** or a different template, not here.

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.overcommit.yml
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.overcommit.yml
@@ -74,6 +74,10 @@ PreCommit:
 PostCheckout:
   BundleInstall:
     enabled: true
+  CustomScript:
+    enabled: true
+    requires_files: false
+    required_executable: 'bin/git-post-checkout-fix'
 
 PostCommit:
   BundleInstall:

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/bin/git-post-checkout-fix
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/bin/git-post-checkout-fix
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# post-checkout: prev_head new_head branch_checkout
+# Git uses a null ref for the previous HEAD on clone and git worktree add.
+NULL_REF='0000000000000000000000000000000000000000'
+
+prev_head="${1:-}"
+branch_checkout="${3:-}"
+
+if [ "${branch_checkout}" != '1' ] || [ "${prev_head}" != "${NULL_REF}" ]; then
+  exit 0
+fi
+
+exec ./fix.sh


### PR DESCRIPTION
## Summary

- Add `bin/git-post-checkout-fix` and `PostCheckout` Overcommit wiring under `{{cookiecutter.project_slug}}/` and the nested project template (meta root already had this from #590).
- Extend `template-hierarchy.mdc` at all three tiers with a propagation checklist: search for parallel boilerplate files and update every tier where they exist; ask the user when scope is unclear.

## Test plan

- [ ] Confirm `bin/git-post-checkout-fix` exists at meta root, `{{cookiecutter.project_slug}}/`, and nested `{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/`.
- [ ] Each `.overcommit.yml` has `PostCheckout` → `CustomScript` → `bin/git-post-checkout-fix`.
- [ ] Bake a child project and verify `git worktree add` runs `fix.sh` in the new worktree.
