### PR TITLE
Use native .githooks post-checkout for fix.sh bootstrap

### DIFF
--- a/.cursor/rules/overcommit-signing.mdc
+++ b/.cursor/rules/overcommit-signing.mdc
@@ -2,7 +2,8 @@
 description: >-
   When git commit fails with overcommit plugin signature or security messages,
   run bin/overcommit --sign and bin/overcommit --sign pre-commit, then retry.
-  In a fresh worktree, also run ./fix.sh first so .ruby-version pins the same
+  In a fresh worktree, ./fix.sh should run automatically via .githooks/post-checkout
+  when core.hooksPath is set; if not, run ./fix.sh so .ruby-version pins the same
   Ruby the git hook will use — overcommit plugin signatures are not stable
   across Ruby versions.
 alwaysApply: false
@@ -22,6 +23,10 @@ Run **both** sign commands every time — not only one. Do not use `--no-verify`
 
 ## Worktrees: pin Ruby first
 
-After `git worktree add`, run `./fix.sh` in the new worktree before signing. `fix.sh` writes `.ruby-version` (gitignored) so rbenv pins the same Ruby in the worktree as in the main checkout.
+After `git worktree add`, `.githooks/post-checkout` runs `./fix.sh` automatically
+when the repo already has `core.hooksPath` set (via a prior `./fix.sh` on the main
+checkout). If the hook did not run, run `./fix.sh` manually in the new worktree.
+`fix.sh` writes `.ruby-version` (gitignored) so rbenv pins the same Ruby in the
+worktree as in the main checkout.
 
 Without this, `bin/overcommit --sign` may run under your global Ruby (e.g. 3.4) while the git pre-commit hook resolves `.ruby-version` from `<main-repo>/.git/hooks/` and runs under the project Ruby (e.g. 3.3). **Overcommit plugin signatures are not stable across Ruby versions** (`hook_config.to_s` formatting changed in Ruby 3.4), so a mismatch makes the hook reject every commit no matter how many times you re-sign. If sign-then-retry keeps failing, instrument the hook to print `RUBY_VERSION` and confirm it matches `ruby -v` from your CLI.

--- a/.cursor/rules/template-hierarchy.mdc
+++ b/.cursor/rules/template-hierarchy.mdc
@@ -23,7 +23,7 @@ This repo is the **meta** cookiecutter (`cookiecutter-cookiecutter`). It bakes *
 |----------------|-----------|-----------------------------------|--------------------|
 | `overcommit-signing.mdc` | Yes | Yes | Yes |
 | `template-hierarchy.mdc` | Yes (this file) | Yes (tier-specific) | Yes (tier-specific) |
-| `fix.sh`, `bin/git-*` hooks, shared `.overcommit.yml` bootstrap | Yes | Yes | Yes |
+| `fix.sh`, `bin/git-*` hooks, `.githooks/post-checkout`, shared `.overcommit.yml` bootstrap | Yes | Yes | Yes |
 | Boilerplate sync skills/docs | No — in baked child path | Yes | No |
 | Language-specific hooks (RuboCop, etc.) | No | Yes | Maybe (framework-only → nested) |
 | Pytest bake-project tips in `DEVELOPMENT.md` | Yes (meta tests) | Yes | No — not every baked project uses Python |
@@ -33,13 +33,13 @@ This repo is the **meta** cookiecutter (`cookiecutter-cookiecutter`). It bakes *
 
 ## Propagate across tiers (agent checklist)
 
-This repo nests **three** template trees (meta root → `{{cookiecutter.project_slug}}/` → nested `{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/`). Many boilerplate files exist at **more than one** path (`fix.sh`, `.overcommit.yml`, `bin/git-commit-validate`, `bin/git-post-checkout-fix`, etc.).
+This repo nests **three** template trees (meta root → `{{cookiecutter.project_slug}}/` → nested `{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/`). Many boilerplate files exist at **more than one** path (`fix.sh`, `.overcommit.yml`, `.githooks/post-checkout`, `bin/git-commit-validate`, `bin/git-post-checkout-fix`, etc.).
 
 When adding or changing such a file:
 
 1. **List tiers** — run `find` or search for the basename under the repo (ignore `.git/`).
 2. **Apply at every tier** where the file already exists, unless the change is intentionally tier-specific.
-3. **Keep paths parallel** — same relative path and hook wiring at each tier (e.g. `PostCheckout` + `bin/git-post-checkout-fix` next to existing `bin/git-push-validate`).
+3. **Keep paths parallel** — same relative path and hook wiring at each tier (e.g. `.githooks/post-checkout` → `bin/git-post-checkout-fix` next to existing `bin/git-push-validate`).
 4. **If unsure** whether a change belongs at one tier or all three, **ask the user** before opening a PR.
 
 When editing the inner template, read `{{cookiecutter.project_slug}}/.cursor/rules/template-hierarchy.mdc` and `docs/SYNCING_BOILERPLATE.md`.

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+exec ./bin/git-post-checkout-fix "$@"

--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,10 @@ types.installed
 # Ignore bundler config.
 /.bundle/config
 
+# Overcommit installs hooks here; only bootstrap post-checkout is tracked
+.githooks/*
+!.githooks/post-checkout
+
 # Ignore make target files
 /.make/*
 !/.make/.keep

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -84,14 +84,6 @@ PreCommit:
     problem_on_unmodified_line: warn
     quiet: false
 
-PostCheckout:
-  BundleInstall:
-    enabled: true
-  CustomScript:
-    enabled: true
-    requires_files: false
-    required_executable: './bin/git-post-checkout-fix'
-
 PostCommit:
   BundleInstall:
     enabled: true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,22 +10,40 @@ When editing the inner template, see `{{cookiecutter.project_slug}}/docs/SYNCING
 
 If you want to use rbenv/pyenv/etc to manage versions of tools,
 there's a `fix.sh` script which may be what you'd like to install
-dependencies.
+dependencies. It sets `git config core.hooksPath .githooks` so tracked
+bootstrap hooks apply to this repo and all its worktrees.
 
-## Worktrees
+## Git hooks and worktrees
 
-After `git worktree add`, run `./fix.sh` once in the new worktree. It
-writes `.ruby-version` (gitignored) and `bundle install`s, so the
-worktree's Ruby and bundler match the main checkout. Skipping this can
-cause overcommit signature mismatches even after re-signing — see
+Bootstrap hooks live in `.githooks/` (plain bash, not Overcommit) so
+`post-checkout` can run `./fix.sh` on clone or `git worktree add` before
+Ruby and Bundler are ready.
+
+For a fresh clone with automatic bootstrap on checkout:
+
+```sh
+git clone -c core.hooksPath=.githooks <url>
+```
+
+Otherwise run `./fix.sh` once after clone — it sets `core.hooksPath` for
+future worktrees.
+
+After `git worktree add`, `.githooks/post-checkout` runs `./fix.sh`
+automatically when the main checkout has already run `./fix.sh` at least
+once. It writes `.ruby-version` (gitignored) and runs `bundle install`,
+so the worktree's Ruby and bundler match the main checkout. Skipping
+bootstrap can cause overcommit signature mismatches even after
+re-signing — see
 [.cursor/rules/overcommit-signing.mdc](.cursor/rules/overcommit-signing.mdc).
 
 ## Overcommit
 
 This project uses [overcommit](https://github.com/sds/overcommit) for
-quality checks.  `.overcommit.yml` sets `gemfile: Gemfile` so git hooks use the
+quality checks on pre-commit, pre-push, and related hooks.
+`.overcommit.yml` sets `gemfile: Gemfile` so those git hooks use the
 same Bundler-managed gem as `bin/overcommit`.  `bundle exec overcommit --install`
-will install hooks.
+will install hooks under `core.hooksPath`. Post-checkout bootstrap is
+handled by `.githooks/post-checkout`, not Overcommit.
 
 If a commit fails with overcommit **plugin signature** or **security**
 messages, run both sign commands before retrying (see

--- a/fix.sh
+++ b/fix.sh
@@ -410,6 +410,29 @@ ensure_shellcheck() {
   fi
 }
 
+ensure_hooks_path() {
+  if [ -d .git ]
+  then
+    git config core.hooksPath .githooks
+  fi
+}
+
+install_bootstrap_post_checkout_hook() {
+  if [ ! -d .githooks ]
+  then
+    mkdir -p .githooks
+  fi
+
+  cat > .githooks/post-checkout << 'EOF'
+#!/bin/bash
+
+set -euo pipefail
+
+exec ./bin/git-post-checkout-fix "$@"
+EOF
+  chmod +x .githooks/post-checkout
+}
+
 ensure_overcommit() {
   # don't run if we're in the middle of a cookiecutter child project
   # test, or otherwise don't have a Git repo to install hooks into...
@@ -418,6 +441,7 @@ ensure_overcommit() {
     bundle exec overcommit --install
     bundle exec overcommit --sign
     bundle exec overcommit --sign pre-commit
+    install_bootstrap_post_checkout_hook
   else
     >&2 echo 'Not in a git repo; not installing git hooks'
   fi
@@ -426,6 +450,8 @@ ensure_overcommit() {
 ensure_types_built() {
   make build-typecheck
 }
+
+ensure_hooks_path
 
 ensure_ruby_versions
 

--- a/{{cookiecutter.project_slug}}/.cursor/rules/overcommit-signing.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/overcommit-signing.mdc
@@ -2,7 +2,8 @@
 description: >-
   When git commit fails with overcommit plugin signature or security messages,
   run bin/overcommit --sign and bin/overcommit --sign pre-commit, then retry.
-  In a fresh worktree, also run ./fix.sh first so .ruby-version pins the same
+  In a fresh worktree, ./fix.sh should run automatically via .githooks/post-checkout
+  when core.hooksPath is set; if not, run ./fix.sh so .ruby-version pins the same
   Ruby the git hook will use — overcommit plugin signatures are not stable
   across Ruby versions.
 alwaysApply: false
@@ -22,6 +23,10 @@ Run **both** sign commands every time — not only one. Do not use `--no-verify`
 
 ## Worktrees: pin Ruby first
 
-After `git worktree add`, run `./fix.sh` in the new worktree before signing. `fix.sh` writes `.ruby-version` (gitignored) so rbenv pins the same Ruby in the worktree as in the main checkout.
+After `git worktree add`, `.githooks/post-checkout` runs `./fix.sh` automatically
+when the repo already has `core.hooksPath` set (via a prior `./fix.sh` on the main
+checkout). If the hook did not run, run `./fix.sh` manually in the new worktree.
+`fix.sh` writes `.ruby-version` (gitignored) so rbenv pins the same Ruby in the
+worktree as in the main checkout.
 
 Without this, `bin/overcommit --sign` may run under your global Ruby (e.g. 3.4) while the git pre-commit hook resolves `.ruby-version` from `<main-repo>/.git/hooks/` and runs under the project Ruby (e.g. 3.3). **Overcommit plugin signatures are not stable across Ruby versions** (`hook_config.to_s` formatting changed in Ruby 3.4), so a mismatch makes the hook reject every commit no matter how many times you re-sign. If sign-then-retry keeps failing, instrument the hook to print `RUBY_VERSION` and confirm it matches `ruby -v` from your CLI.

--- a/{{cookiecutter.project_slug}}/.cursor/rules/template-hierarchy.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/template-hierarchy.mdc
@@ -16,7 +16,7 @@ Cookiecutter templates in this family stack **general → specific** (meta → l
 |----------------|---------------|---------------|----------------------------------------------------------------|
 | `overcommit-signing.mdc` | Yes | Yes | Yes |
 | `template-hierarchy.mdc` | Yes | Yes (this file) | Yes (project tier) |
-| `fix.sh`, `bin/git-*` hooks, shared `.overcommit.yml` bootstrap | Yes | Yes | Yes |
+| `fix.sh`, `bin/git-*` hooks, `.githooks/post-checkout`, shared `.overcommit.yml` bootstrap | Yes | Yes | Yes |
 | Boilerplate sync skill + `SYNCING_BOILERPLATE.md` | Baked path only | **Yes** | No |
 | Language hooks (RuboCop, etc.) | No | **Yes** | Framework-only → nested |
 | Pytest bake tips in `DEVELOPMENT.md` | Meta repo | **Yes** if this template uses pytest | No — not every baked project uses Python |

--- a/{{cookiecutter.project_slug}}/.githooks/post-checkout
+++ b/{{cookiecutter.project_slug}}/.githooks/post-checkout
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+exec ./bin/git-post-checkout-fix "$@"

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -117,6 +117,10 @@ types.installed
 # Ignore bundler config.
 /.bundle/config
 
+# Overcommit installs hooks here; only bootstrap post-checkout is tracked
+.githooks/*
+!.githooks/post-checkout
+
 # Ignore make target files
 /.make/*
 !/.make/.keep

--- a/{{cookiecutter.project_slug}}/.overcommit.yml
+++ b/{{cookiecutter.project_slug}}/.overcommit.yml
@@ -84,14 +84,6 @@ PreCommit:
     problem_on_unmodified_line: warn
     quiet: false
 
-PostCheckout:
-  BundleInstall:
-    enabled: true
-  CustomScript:
-    enabled: true
-    requires_files: false
-    required_executable: 'bin/git-post-checkout-fix'
-
 PostCommit:
   BundleInstall:
     enabled: true

--- a/{{cookiecutter.project_slug}}/DEVELOPMENT.md
+++ b/{{cookiecutter.project_slug}}/DEVELOPMENT.md
@@ -4,22 +4,40 @@
 
 If you want to use rbenv/pyenv/etc to manage versions of tools,
 there's a `fix.sh` script which may be what you'd like to install
-dependencies.
+dependencies. It sets `git config core.hooksPath .githooks` so tracked
+bootstrap hooks apply to this repo and all its worktrees.
 
-## Worktrees
+## Git hooks and worktrees
 
-After `git worktree add`, run `./fix.sh` once in the new worktree. It
-writes `.ruby-version` (gitignored) and `bundle install`s, so the
-worktree's Ruby and bundler match the main checkout. Skipping this can
-cause overcommit signature mismatches even after re-signing — see
+Bootstrap hooks live in `.githooks/` (plain bash, not Overcommit) so
+`post-checkout` can run `./fix.sh` on clone or `git worktree add` before
+Ruby and Bundler are ready.
+
+For a fresh clone with automatic bootstrap on checkout:
+
+```sh
+git clone -c core.hooksPath=.githooks <url>
+```
+
+Otherwise run `./fix.sh` once after clone — it sets `core.hooksPath` for
+future worktrees.
+
+After `git worktree add`, `.githooks/post-checkout` runs `./fix.sh`
+automatically when the main checkout has already run `./fix.sh` at least
+once. It writes `.ruby-version` (gitignored) and runs `bundle install`,
+so the worktree's Ruby and bundler match the main checkout. Skipping
+bootstrap can cause overcommit signature mismatches even after
+re-signing — see
 [.cursor/rules/overcommit-signing.mdc](.cursor/rules/overcommit-signing.mdc).
 
 ## Overcommit
 
 This project uses [overcommit](https://github.com/sds/overcommit) for
-quality checks.  `.overcommit.yml` sets `gemfile: Gemfile` so git hooks use the
+quality checks on pre-commit, pre-push, and related hooks.
+`.overcommit.yml` sets `gemfile: Gemfile` so those git hooks use the
 same Bundler-managed gem as `bin/overcommit`.  `bundle exec overcommit --install`
-will install hooks.
+will install hooks under `core.hooksPath`. Post-checkout bootstrap is
+handled by `.githooks/post-checkout`, not Overcommit.
 
 If a commit fails with overcommit **plugin signature** or **security**
 messages, run both sign commands before retrying (see

--- a/{{cookiecutter.project_slug}}/fix.sh
+++ b/{{cookiecutter.project_slug}}/fix.sh
@@ -410,6 +410,29 @@ ensure_shellcheck() {
   fi
 }
 
+ensure_hooks_path() {
+  if [ -d .git ]
+  then
+    git config core.hooksPath .githooks
+  fi
+}
+
+install_bootstrap_post_checkout_hook() {
+  if [ ! -d .githooks ]
+  then
+    mkdir -p .githooks
+  fi
+
+  cat > .githooks/post-checkout << 'EOF'
+#!/bin/bash
+
+set -euo pipefail
+
+exec ./bin/git-post-checkout-fix "$@"
+EOF
+  chmod +x .githooks/post-checkout
+}
+
 ensure_overcommit() {
   # don't run if we're in the middle of a cookiecutter child project
   # test, or otherwise don't have a Git repo to install hooks into...
@@ -418,6 +441,7 @@ ensure_overcommit() {
     bundle exec overcommit --install
     bundle exec overcommit --sign
     bundle exec overcommit --sign pre-commit
+    install_bootstrap_post_checkout_hook
   else
     >&2 echo 'Not in a git repo; not installing git hooks'
   fi
@@ -426,6 +450,8 @@ ensure_overcommit() {
 ensure_types_built() {
   make build-typecheck
 }
+
+ensure_hooks_path
 
 ensure_ruby_versions
 

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.cursor/rules/overcommit-signing.mdc
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.cursor/rules/overcommit-signing.mdc
@@ -2,7 +2,8 @@
 description: >-
   When git commit fails with overcommit plugin signature or security messages,
   run bin/overcommit --sign and bin/overcommit --sign pre-commit, then retry.
-  In a fresh worktree, also run ./fix.sh first so .ruby-version pins the same
+  In a fresh worktree, ./fix.sh should run automatically via .githooks/post-checkout
+  when core.hooksPath is set; if not, run ./fix.sh so .ruby-version pins the same
   Ruby the git hook will use — overcommit plugin signatures are not stable
   across Ruby versions.
 alwaysApply: false
@@ -22,6 +23,10 @@ Run **both** sign commands every time — not only one. Do not use `--no-verify`
 
 ## Worktrees: pin Ruby first
 
-After `git worktree add`, run `./fix.sh` in the new worktree before signing. `fix.sh` writes `.ruby-version` (gitignored) so rbenv pins the same Ruby in the worktree as in the main checkout.
+After `git worktree add`, `.githooks/post-checkout` runs `./fix.sh` automatically
+when the repo already has `core.hooksPath` set (via a prior `./fix.sh` on the main
+checkout). If the hook did not run, run `./fix.sh` manually in the new worktree.
+`fix.sh` writes `.ruby-version` (gitignored) so rbenv pins the same Ruby in the
+worktree as in the main checkout.
 
 Without this, `bin/overcommit --sign` may run under your global Ruby (e.g. 3.4) while the git pre-commit hook resolves `.ruby-version` from `<main-repo>/.git/hooks/` and runs under the project Ruby (e.g. 3.3). **Overcommit plugin signatures are not stable across Ruby versions** (`hook_config.to_s` formatting changed in Ruby 3.4), so a mismatch makes the hook reject every commit no matter how many times you re-sign. If sign-then-retry keeps failing, instrument the hook to print `RUBY_VERSION` and confirm it matches `ruby -v` from your CLI.

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.cursor/rules/template-hierarchy.mdc
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.cursor/rules/template-hierarchy.mdc
@@ -22,7 +22,7 @@ alwaysApply: false
 
 ## Propagate across tiers (agent checklist)
 
-Cross-language boilerplate (`fix.sh`, `.overcommit.yml`, `bin/git-*`, etc.) is mirrored at **meta root**, the language/tool template, and **this** nested project template. When editing one copy, check whether the same file exists upstream or downstream and keep all applicable tiers in sync. If unsure whether a change belongs here only or at every tier, **ask the user**. See ancestor `template-hierarchy.mdc` rules (meta and `{{ cookiecutter.project_slug }}/`).
+Cross-language boilerplate (`fix.sh`, `.overcommit.yml`, `.githooks/post-checkout`, `bin/git-*`, etc.) is mirrored at **meta root**, the language/tool template, and **this** nested project template. When editing one copy, check whether the same file exists upstream or downstream and keep all applicable tiers in sync. If unsure whether a change belongs here only or at every tier, **ask the user**. See ancestor `template-hierarchy.mdc` rules (meta and `{{ cookiecutter.project_slug }}/`).
 
 ## Referenced paths must exist here
 

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.githooks/post-checkout
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.githooks/post-checkout
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+exec ./bin/git-post-checkout-fix "$@"

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.gitignore
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.gitignore
@@ -55,6 +55,10 @@ types.installed
 # Ignore bundler config.
 /.bundle/config
 
+# Overcommit installs hooks here; only bootstrap post-checkout is tracked
+.githooks/*
+!.githooks/post-checkout
+
 # Ignore make target files
 /.make/*
 !/.make/.keep

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.overcommit.yml
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.overcommit.yml
@@ -71,14 +71,6 @@ PreCommit:
     problem_on_unmodified_line: warn
     quiet: false
 
-PostCheckout:
-  BundleInstall:
-    enabled: true
-  CustomScript:
-    enabled: true
-    requires_files: false
-    required_executable: 'bin/git-post-checkout-fix'
-
 PostCommit:
   BundleInstall:
     enabled: true

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/DEVELOPMENT.md
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/DEVELOPMENT.md
@@ -4,22 +4,40 @@
 
 If you want to use rbenv/pyenv/etc to manage versions of tools,
 there's a `fix.sh` script which may be what you'd like to install
-dependencies.
+dependencies. It sets `git config core.hooksPath .githooks` so tracked
+bootstrap hooks apply to this repo and all its worktrees.
 
-## Worktrees
+## Git hooks and worktrees
 
-After `git worktree add`, run `./fix.sh` once in the new worktree. It
-writes `.ruby-version` (gitignored) and `bundle install`s, so the
-worktree's Ruby and bundler match the main checkout. Skipping this can
-cause overcommit signature mismatches even after re-signing — see
+Bootstrap hooks live in `.githooks/` (plain bash, not Overcommit) so
+`post-checkout` can run `./fix.sh` on clone or `git worktree add` before
+Ruby and Bundler are ready.
+
+For a fresh clone with automatic bootstrap on checkout:
+
+```sh
+git clone -c core.hooksPath=.githooks <url>
+```
+
+Otherwise run `./fix.sh` once after clone — it sets `core.hooksPath` for
+future worktrees.
+
+After `git worktree add`, `.githooks/post-checkout` runs `./fix.sh`
+automatically when the main checkout has already run `./fix.sh` at least
+once. It writes `.ruby-version` (gitignored) and runs `bundle install`,
+so the worktree's Ruby and bundler match the main checkout. Skipping
+bootstrap can cause overcommit signature mismatches even after
+re-signing — see
 [.cursor/rules/overcommit-signing.mdc](.cursor/rules/overcommit-signing.mdc).
 
 ## Overcommit
 
 This project uses [overcommit](https://github.com/sds/overcommit) for
-quality checks.  `.overcommit.yml` sets `gemfile: Gemfile` so git hooks use the
+quality checks on pre-commit, pre-push, and related hooks.
+`.overcommit.yml` sets `gemfile: Gemfile` so those git hooks use the
 same Bundler-managed gem as `bin/overcommit`.  `bundle exec overcommit --install`
-will install hooks.
+will install hooks under `core.hooksPath`. Post-checkout bootstrap is
+handled by `.githooks/post-checkout`, not Overcommit.
 
 If a commit fails with overcommit **plugin signature** or **security**
 messages, run both sign commands before retrying (see

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/fix.sh
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/fix.sh
@@ -405,6 +405,29 @@ ensure_shellcheck() {
   fi
 }
 
+ensure_hooks_path() {
+  if [ -d .git ]
+  then
+    git config core.hooksPath .githooks
+  fi
+}
+
+install_bootstrap_post_checkout_hook() {
+  if [ ! -d .githooks ]
+  then
+    mkdir -p .githooks
+  fi
+
+  cat > .githooks/post-checkout << 'EOF'
+#!/bin/bash
+
+set -euo pipefail
+
+exec ./bin/git-post-checkout-fix "$@"
+EOF
+  chmod +x .githooks/post-checkout
+}
+
 ensure_overcommit() {
   # don't run if we're in the middle of a cookiecutter child project
   # test, or otherwise don't have a Git repo to install hooks into...
@@ -413,6 +436,7 @@ ensure_overcommit() {
     bundle exec overcommit --install
     bundle exec overcommit --sign
     bundle exec overcommit --sign pre-commit
+    install_bootstrap_post_checkout_hook
   else
     >&2 echo 'Not in a git repo; not installing git hooks'
   fi
@@ -421,6 +445,8 @@ ensure_overcommit() {
 ensure_types_built() {
   make build-typecheck
 }
+
+ensure_hooks_path
 
 ensure_ruby_versions
 


### PR DESCRIPTION
## Summary

- Move clone/worktree bootstrap off Overcommit: add tracked `.githooks/post-checkout` (plain bash) that delegates to `bin/git-post-checkout-fix` and runs `./fix.sh` only when Git reports a null previous HEAD.
- `fix.sh` now sets `core.hooksPath` to `.githooks` at bootstrap start and restores the bootstrap hook after `overcommit --install` (Overcommit otherwise overwrites `post-checkout` in that directory).
- Remove the `PostCheckout` section from `.overcommit.yml`; Overcommit continues to manage pre-commit, pre-push, and related hooks only.
- Propagate across all three template tiers; update `DEVELOPMENT.md`, `overcommit-signing.mdc`, and `template-hierarchy.mdc`; gitignore generated Overcommit hooks under `.githooks/`.

## Test plan

- [ ] `git clone -c core.hooksPath=.githooks <url>` runs `./fix.sh` on first checkout.
- [ ] After a normal clone + `./fix.sh`, `git worktree add ../test-worktree` auto-runs `./fix.sh` in the new worktree.
- [ ] `git checkout main` on an existing clone does **not** run `fix.sh`.
- [ ] `./fix.sh` leaves a bash `post-checkout` in `.githooks/` (not the Overcommit Ruby wrapper) after `overcommit --install`.
- [ ] Pre-commit hooks still pass after bootstrap.
