### PR TITLE
Sync env.local boilerplate and private-reference naming rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ commands:
     steps:
       - run:
           name: <<parameters.label>>
+          no_output_timeout: 30m
           command: |
             export PATH="${HOME}/.pyenv/bin:${PATH}"
             export PATH="${HOME}/.rbenv/bin:${HOME}/.rbenv/shims:${PATH}"

--- a/.cursor/rules/template-hierarchy.mdc
+++ b/.cursor/rules/template-hierarchy.mdc
@@ -43,7 +43,7 @@ The **meta** tier is cross-language. Do not let a Ruby gem or app reference driv
 
 Language-agnostic ports (e.g. `.yamllint.yml` comments, `bin/overcommit` binstub maintenance) are still fine when they apply at every tier.
 
-## Syncing from baked Ruby apps (e.g. `apiology/plate-spinner`)
+## Syncing from baked Ruby apps (private reference repos)
 
 A **baked** gem or app (created from `cookiecutter-gem`, not the meta template) is a useful reference for **production** patterns, but most of its tree is **more specific** than any cookiecutter tier here. Use `git show origin/main:<path>` on the reference and classify before copying.
 
@@ -58,7 +58,7 @@ A **baked** gem or app (created from `cookiecutter-gem`, not the meta template) 
 
 **`fix.sh` rugged:** `ensure_rugged_packages_installed` is **Ruby-repo-specific** (undercover). Put it in **`cookiecutter-gem`** and baked Ruby apps — **not** in this meta repo’s generic `{{cookiecutter.project_slug}}/` tree (language-agnostic until you bake a Ruby cookiecutter).
 
-**Workflow:** sync plate-spinner → **`cookiecutter-gem`** first; pull **agnostic** pieces up to meta only when they apply to every tier. Record reference `origin/main` SHA in the PR.
+**Workflow:** sync from the baked gem into **`cookiecutter-gem`** first; pull **agnostic** pieces up to meta only when they apply to every tier. Record the reference `origin/main` SHA in the PR (repo name omitted from public text).
 
 ## Propagate across tiers (agent checklist)
 

--- a/.cursor/rules/template-hierarchy.mdc
+++ b/.cursor/rules/template-hierarchy.mdc
@@ -37,11 +37,28 @@ The **meta** tier is cross-language. Do not let a Ruby gem or app reference driv
 
 | Do not port to meta | Belongs in |
 |---------------------|------------|
-| `fix.sh`: `rbenv install --list-all`, `set_ruby_local_version` (`tail -1`, extra `set_rbenv_env_variables`), `ensure_rugged_packages_installed`, standalone `ensure_rbenv` before the main flow | Ruby language cookiecutter |
+| `fix.sh`: `rbenv install --list-all`, `set_ruby_local_version` (`tail -1`, extra `set_rbenv_env_variables`), `ensure_rugged_packages_installed`, standalone `ensure_rbenv` before the main flow | **Ruby repos only** (e.g. `cookiecutter-gem`), not this generic language template |
 | `.gitignore`: `tapioca.installed`, `yardoc.installed`, `sorbet/machine_specific_config` | Ruby / Sorbet templates |
 | `.git-hooks/**/*.rb`: `# @sg-ignore` and other Sorbet-only annotation churn | Ruby cookiecutters |
 
 Language-agnostic ports (e.g. `.yamllint.yml` comments, `bin/overcommit` binstub maintenance) are still fine when they apply at every tier.
+
+## Syncing from baked Ruby apps (e.g. `apiology/plate-spinner`)
+
+A **baked** gem or app (created from `cookiecutter-gem`, not the meta template) is a useful reference for **production** patterns, but most of its tree is **more specific** than any cookiecutter tier here. Use `git show origin/main:<path>` on the reference and classify before copying.
+
+| Usually safe to port (all tiers that already have the file) | Usually **do not** port into cookiecutter templates |
+|-------------------------------------------------------------|-----------------------------------------------------|
+| `config/env.local` + `.envrc` prefer-local-over-`op run` | `.overcommit.yml`: RuboCop, Sorbet, Solargraph, Brakeman, Fasterer, BundleAudit, RakeTarget prepush |
+| `DEVELOPMENT.md` 1Password / `env.local` docs (generic names, not app slug) | `.yamllint.yml`: `rbs_collection.lock.yaml`, app YAML paths (e.g. `partials.yaml`) |
+| `.dockerignore` `/config/env.local` | `.circleci`: `checkout: method: full`, debug `pwd`, `*.gemspec` cache keys |
+| `.circleci` `no_output_timeout` on long steps | `Makefile` / `Gemfile` / `requirements_dev.txt` app layout |
+| `config/env.local` in `.gitignore` | `fix.sh`: `ensure_rugged_packages_installed` (**Ruby repos only**), `ensure_handlebars_engine_packages_installed`, `ensure_mini_racer_packages_installed`, `ensure_chromedriver_correct_platform` |
+| | App `lib/`, `config/annotations*.rb`, `script/`, Heroku app names, plate-specific docs |
+
+**`fix.sh` rugged:** `ensure_rugged_packages_installed` is **Ruby-repo-specific** (undercover). Put it in **`cookiecutter-gem`** and baked Ruby apps — **not** in this meta repo’s generic `{{cookiecutter.project_slug}}/` tree (language-agnostic until you bake a Ruby cookiecutter).
+
+**Workflow:** sync plate-spinner → **`cookiecutter-gem`** first; pull **agnostic** pieces up to meta only when they apply to every tier. Record reference `origin/main` SHA in the PR.
 
 ## Propagate across tiers (agent checklist)
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,7 @@
 
 # used for local dev only
 /config/env.1p
+/config/env.local
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/.envrc
+++ b/.envrc
@@ -6,4 +6,29 @@
 
 PATH_add bin
 
-direnv_load op run --cache --env-file=config/env.1p -- direnv dump
+watch_file config/env.1p
+watch_file config/env.local
+
+if [[ -r config/env.local ]]; then
+  if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
+    echo "config/env.local must contain resolved values, not op:// references." >&2
+    exit 1
+  fi
+  eval "$(
+    ENV_LOCAL_FILE=config/env.local ruby -rshellwords -e '
+      File.foreach(ENV.fetch("ENV_LOCAL_FILE")) do |line|
+        line = line.strip
+        next if line.empty? || line.start_with?("#")
+        key, value = line.split("=", 2)
+        next if value.nil?
+        value = value.strip
+        if value.length >= 2 && value.start_with?("\"") && value.end_with?("\"")
+          value = value[1..-2]
+        end
+        puts "export #{Shellwords.escape(key)}=#{Shellwords.escape(value)}"
+      end
+    '
+  )"
+else
+  direnv_load op run --cache --env-file=config/env.1p -- direnv dump
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,9 @@ types.installed
 # Ignore bundler config.
 /.bundle/config
 
+# 1Password Environment local mount (resolved literals; template is config/env.1p)
+/config/env.local
+
 # Overcommit installs hooks here; only bootstrap post-checkout is tracked
 .githooks/*
 !.githooks/post-checkout

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -26,6 +26,7 @@ PreCommit:
     exclude:
       # used for development
       - 'config/env.1p'
+      - 'config/env.local'
   FixMe:
     enabled: true
     exclude:
@@ -64,6 +65,7 @@ PreCommit:
       - '{{cookiecutter.project_slug}}/**/*'
       # used for development
       - 'config/env.1p'
+      - 'config/env.local'
       # sorbet sure likes to crash
       - 'core.*'
       # don't freak out over line below

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -59,6 +59,82 @@ bin/overcommit --sign pre-commit
 This project uses direnv to manage environment variables used during
 development.  See the `.envrc` file for detail.
 
+### Secrets: `config/env.1p` and 1Password
+
+`config/env.1p` in git is the **template**: each variable points at a vault
+item with an `op://` [secret
+reference](https://developer.1password.com/docs/cli/secret-reference), not a
+plaintext value.  `.envrc` and `make config/env` prefer **`config/env.local`**
+when that file is readable (1Password Environment mount with resolved
+literals); otherwise they use `op run --env-file=config/env.1p` (always in
+git) to resolve references at load time.
+
+For local development, you can also store **resolved** values in a
+[1Password Environment](https://developer.1password.com/docs/environments/) and mount
+them as a [local `.env`
+file](https://developer.1password.com/docs/environments/local-env-file/) at
+**`config/env.local`** (macOS beta; fifo mount, gitignored).  Do **not**
+mount at `config/env.1p` — that path is the tracked `op://` template and
+conflicts with git.  When vault items change or you add keys to the template,
+refresh the Environment with `op inject` and the 1Password app.
+
+#### Prerequisites (macOS)
+
+* [1Password for Mac](https://1password.com/downloads/mac/) with **Developer**
+  turned on (Settings → Developer).
+* [1Password CLI](https://developer.1password.com/docs/cli/get-started/):
+  `brew install 1password-cli`
+* Signed in: `op signin` (or 1Password app integration enabled).
+* 1Password unlocked when you run `op inject`.
+
+#### One-time: Environment and local mount
+
+1. Open 1Password → **Developer** → **View Environments**.
+2. Open (or create) the environment for this repo.
+3. Under **Destinations**, add **Local .env file** and set the path to this
+   repo’s **`config/env.local`** (use an absolute path, e.g.
+   `$PWD/config/env.local` from the repo root).
+4. Approve access when prompted; keep 1Password running while developing.
+
+| Path | Role |
+|------|------|
+| `config/env.1p` | Git-tracked template (`op://` references); fallback for `.envrc` / `make config/env` |
+| `config/env.local` | 1Password Environment mount (resolved literals); preferred when present |
+
+Do not commit `config/env.local`.
+
+#### Update the Environment from `config/env.1p` (`op inject`)
+
+Use this when you have changed `config/env.1p` in git (new variables or
+updated `op://` paths) or when secrets in 1Password vaults have changed and
+you want the Environment to match current vault values.
+
+1. From the repo root, resolve the template to a **temporary** file (never
+   write injected secrets back onto the tracked `config/env.1p`):
+
+   ```sh
+   op inject -i config/env.1p -o /tmp/repo-env.import -f
+   ```
+
+2. Confirm every reference resolved (no `op://` left):
+
+   ```sh
+   grep 'op://' /tmp/repo-env.import && echo 'ERROR: unresolved references' || echo 'OK'
+   ```
+
+3. Import into 1Password, then `rm /tmp/repo-env.import`.
+
+4. If you use a local mount at `config/env.local`, confirm
+   `grep -c op:// config/env.local` is **0**, then `direnv allow`.
+
+#### Avoid duplicate variables
+
+1Password Environments allow **multiple entries with the same name**.  The
+mounted `config/env.local` will then mix `op://` lines with resolved values,
+and `.envrc` will fail its `op://` check.  **Clean reset:** delete all
+variables in the Environment, `op inject` once, import that file, and confirm
+`grep -c op:// config/env.local` is **0**.
+
 ## Test performance
 
 To get full realtime output from tests to debug e.g. slowness issues:

--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -15,6 +15,7 @@ commands:
     steps:
       - run:
           name: <<parameters.label>>
+          no_output_timeout: 30m
           command: |
             export PATH="${HOME}/.pyenv/bin:${PATH}"
             export PATH="${HOME}/.rbenv/bin:${HOME}/.rbenv/shims:${PATH}"

--- a/{{cookiecutter.project_slug}}/.cursor/rules/boilerplate-sync.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/boilerplate-sync.mdc
@@ -16,6 +16,6 @@ When syncing from **reference repos** (production projects on `origin/main`):
 2. Read [docs/SYNCING_BOILERPLATE.md](../docs/SYNCING_BOILERPLATE.md).
 3. **Only** `git show origin/main:<path>` — never unpushed local trees.
 4. Follow [template-hierarchy.mdc](template-hierarchy.mdc) for what belongs at **this** level vs ancestors vs descendants.
-5. At the **meta** tier, never port Ruby-only `fix.sh`, Sorbet/Tapioca/YARD `.gitignore` entries, or `# @sg-ignore` hook churn from Ruby app references (e.g. checkoff, plate-spinner) — see [SYNCING_BOILERPLATE.md](../docs/SYNCING_BOILERPLATE.md).
-6. From **baked** Ruby apps (`plate-spinner`, etc.): do **not** copy reference `.overcommit.yml` / Ruby `.yamllint.yml` hooks or CircleCI `method: full` / `pwd`; do **not** copy **`rugged`** / `handlebars` / `mini_racer` / `chromedriver` `fix.sh` helpers into this **generic** language template — **`rugged` belongs in Ruby repos only** (e.g. `cookiecutter-gem`).
+5. At the **meta** tier, never port Ruby-only `fix.sh`, Sorbet/Tapioca/YARD `.gitignore` entries, or `# @sg-ignore` hook churn from Ruby app references (e.g. checkoff) — see [SYNCING_BOILERPLATE.md](../docs/SYNCING_BOILERPLATE.md).
+6. From **baked** private Ruby apps: do **not** copy reference `.overcommit.yml` / Ruby `.yamllint.yml` hooks or CircleCI `method: full` / `pwd`; do **not** copy **`rugged`** / `handlebars` / `mini_racer` / `chromedriver` `fix.sh` helpers into this **generic** language template — **`rugged` belongs in Ruby repos only** (e.g. `cookiecutter-gem`). Do **not** name private reference repos in public commits or docs.
 7. Classify each diff: agnostic → propagate all tiers that hold the file; Ruby-tool → language template only; app-only → descendant or never.

--- a/{{cookiecutter.project_slug}}/.cursor/rules/boilerplate-sync.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/boilerplate-sync.mdc
@@ -16,4 +16,6 @@ When syncing from **reference repos** (production projects on `origin/main`):
 2. Read [docs/SYNCING_BOILERPLATE.md](../docs/SYNCING_BOILERPLATE.md).
 3. **Only** `git show origin/main:<path>` — never unpushed local trees.
 4. Follow [template-hierarchy.mdc](template-hierarchy.mdc) for what belongs at **this** level vs ancestors vs descendants.
-5. At the **meta** tier, never port Ruby-only `fix.sh`, Sorbet/Tapioca/YARD `.gitignore` entries, or `# @sg-ignore` hook churn from Ruby app references (e.g. checkoff) — see [SYNCING_BOILERPLATE.md](../docs/SYNCING_BOILERPLATE.md).
+5. At the **meta** tier, never port Ruby-only `fix.sh`, Sorbet/Tapioca/YARD `.gitignore` entries, or `# @sg-ignore` hook churn from Ruby app references (e.g. checkoff, plate-spinner) — see [SYNCING_BOILERPLATE.md](../docs/SYNCING_BOILERPLATE.md).
+6. From **baked** Ruby apps (`plate-spinner`, etc.): do **not** copy reference `.overcommit.yml` / Ruby `.yamllint.yml` hooks or CircleCI `method: full` / `pwd`; do **not** copy **`rugged`** / `handlebars` / `mini_racer` / `chromedriver` `fix.sh` helpers into this **generic** language template — **`rugged` belongs in Ruby repos only** (e.g. `cookiecutter-gem`).
+7. Classify each diff: agnostic → propagate all tiers that hold the file; Ruby-tool → language template only; app-only → descendant or never.

--- a/{{cookiecutter.project_slug}}/.cursor/rules/template-hierarchy.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/template-hierarchy.mdc
@@ -54,14 +54,17 @@ When porting config that names directories or tools (`.envrc` `PATH_add`, Makefi
 
 | Config | Ancestor (most general) | This / language tier | Descendant (more specific) |
 |--------|-------------------------|----------------------|----------------------------|
-| `.yamllint.yml` | `.circleci` line-length ignore only | May add language-appropriate ignores | Framework/app YAML paths |
-| `.overcommit.yml` | Generic hooks only | RuboCop, Sorbet, etc. | Rails-only hooks |
-| `Makefile` / `fix.sh` | Cross-language bootstrap | Language toolchain targets | App/deploy targets |
+| `.yamllint.yml` | `.circleci` line-length ignore only | Same unless this repo is Ruby-only | App YAML paths (`partials.yaml`, `rbs_collection.lock.yaml`) |
+| `.overcommit.yml` | Generic hooks only (no RuboCop/Sorbet/Brakeman) | Same in cookiecutter templates; baked apps add hooks in **their** repos | App-only hooks |
+| `Makefile` / `fix.sh` | Cross-language bootstrap | Ruby toolchain only if this template is Ruby (not rugged here by default) | `rugged`, `handlebars`, `mini_racer`, `chromedriver` — **Ruby/app repos** |
 | Paths | None of `lib/`, `app/` | Language test/layout conventions | Framework `config/` |
 | `.envrc` `PATH_add` | `bin` only (if `bin/` exists) | Add paths that exist here (e.g. `script/` when present) | App-only paths |
-| `fix.sh` rbenv / rugged / `set_ruby_local_version` | **Do not port from Ruby app refs** | Ruby toolchain bootstrap | App-only Ruby deps (e.g. rugged for undercover) |
+| `fix.sh` rbenv / `set_ruby_local_version` | **Do not port churn from Ruby app refs** | Ruby toolchain when this is a Ruby template | **`rugged`** (Ruby/undercover), `handlebars`, `mini_racer`, `chromedriver` |
 | `.gitignore` Sorbet / Tapioca / YARD | **Do not port from Ruby app refs** | `tapioca.installed`, `yardoc.installed`, `sorbet/*` | Generated RBI paths |
 | `.git-hooks` `# @sg-ignore` | **Do not port** | Sorbet annotations only in Ruby templates | — |
+| `.circleci` | `no_output_timeout`, shared cache pattern | Same | `method: full`, `pwd`, `*.gemspec` cache keys |
+
+When syncing from a **baked** reference (e.g. `apiology/plate-spinner`), read [SYNCING_BOILERPLATE.md](../docs/SYNCING_BOILERPLATE.md) § baked Ruby apps — do not paste the reference’s full `.overcommit.yml` or Ruby yamllint/Sorbet blocks into cookiecutter templates.
 
 When syncing into the **meta** ancestor from a Ruby reference (e.g. `apiology/checkoff`), see the meta rule `template-hierarchy.mdc` — Ruby-only rows above stay out of meta copies.
 

--- a/{{cookiecutter.project_slug}}/.cursor/rules/template-hierarchy.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/template-hierarchy.mdc
@@ -64,7 +64,7 @@ When porting config that names directories or tools (`.envrc` `PATH_add`, Makefi
 | `.git-hooks` `# @sg-ignore` | **Do not port** | Sorbet annotations only in Ruby templates | — |
 | `.circleci` | `no_output_timeout`, shared cache pattern | Same | `method: full`, `pwd`, `*.gemspec` cache keys |
 
-When syncing from a **baked** reference (e.g. `apiology/plate-spinner`), read [SYNCING_BOILERPLATE.md](../docs/SYNCING_BOILERPLATE.md) § baked Ruby apps — do not paste the reference’s full `.overcommit.yml` or Ruby yamllint/Sorbet blocks into cookiecutter templates.
+When syncing from a **baked** private reference, read [SYNCING_BOILERPLATE.md](../docs/SYNCING_BOILERPLATE.md) § baked Ruby apps — do not paste the reference’s full `.overcommit.yml` or Ruby yamllint/Sorbet blocks into cookiecutter templates, and do not name private reference repos in public text.
 
 When syncing into the **meta** ancestor from a Ruby reference (e.g. `apiology/checkoff`), see the meta rule `template-hierarchy.mdc` — Ruby-only rows above stay out of meta copies.
 

--- a/{{cookiecutter.project_slug}}/.cursor/skills/apiology-boilerplate-sync/SKILL.md
+++ b/{{cookiecutter.project_slug}}/.cursor/skills/apiology-boilerplate-sync/SKILL.md
@@ -66,13 +66,24 @@ Before porting: `git ls-tree origin/main -- <path>`.
 
 ## Meta tier: Ruby reference exclusions
 
-If the reference is a **Ruby app or gem** (e.g. `checkoff`) and you are at the **meta** cookiecutter, do **not** port Ruby-only bootstrap or Sorbet artifacts into shared files:
+If the reference is a **Ruby app or gem** (e.g. `checkoff`, `plate-spinner`) and you are at the **meta** cookiecutter, do **not** port Ruby-only bootstrap or Sorbet artifacts into shared files:
 
-- `fix.sh`: rbenv `--list-all`, `set_ruby_local_version` / rugged / extra `ensure_rbenv`
+- `fix.sh`: rbenv `--list-all`, `set_ruby_local_version` churn, `ensure_rugged_packages_installed` (**Ruby repos only** — not generic language templates), extra `ensure_rbenv`; project-only `handlebars` / `mini_racer` / `chromedriver` helpers
 - `.gitignore`: `tapioca.installed`, `yardoc.installed`, `sorbet/machine_specific_config`
 - `.git-hooks/**/*.rb`: `# @sg-ignore` and Sorbet-only annotations
+- `.overcommit.yml` / `.yamllint.yml`: RuboCop, Sorbet, Solargraph, Brakeman, Fasterer, BundleAudit, Rake prepush, `sorbet/**` or `rbs_collection.lock.yaml` ignores
+- `.circleci/config.yml`: `checkout: method: full`, debug `pwd`, app-specific cache checksums
 
-Use a Ruby language cookiecutter for those. Details: [template-hierarchy.mdc](../../.cursor/rules/template-hierarchy.mdc), [SYNCING_BOILERPLATE.md](../../docs/SYNCING_BOILERPLATE.md).
+**Rugged** (`ensure_rugged_packages_installed`) is **Ruby-repo-specific** — add it in `cookiecutter-gem` (or the baked app), not in this meta repo’s generic language template. Details: [template-hierarchy.mdc](../../.cursor/rules/template-hierarchy.mdc), [SYNCING_BOILERPLATE.md](../../docs/SYNCING_BOILERPLATE.md).
+
+## Baked app references (e.g. `plate-spinner`)
+
+Before copying from a **production** repo into a cookiecutter template:
+
+1. Identify which cookiecutter tier you are editing (meta / language / nested project).
+2. Run a path-by-path diff; reject anything under `lib/`, app `config/`, or project-only `Makefile` / `Gemfile` unless this tier is meant to generate that layout.
+3. **Good ports:** `env.local` + `.envrc`, 1Password docs, `.dockerignore`, `no_output_timeout`, `config/env.local` gitignore.
+4. **Bad ports:** full reference `.overcommit.yml`, reference `.yamllint.yml` Ruby/Sorbet blocks, CircleCI debugging checkout, project native deps in `fix.sh` (see SYNCING doc).
 
 ## Quick baseline
 

--- a/{{cookiecutter.project_slug}}/.cursor/skills/apiology-boilerplate-sync/SKILL.md
+++ b/{{cookiecutter.project_slug}}/.cursor/skills/apiology-boilerplate-sync/SKILL.md
@@ -66,7 +66,7 @@ Before porting: `git ls-tree origin/main -- <path>`.
 
 ## Meta tier: Ruby reference exclusions
 
-If the reference is a **Ruby app or gem** (e.g. `checkoff`, `plate-spinner`) and you are at the **meta** cookiecutter, do **not** port Ruby-only bootstrap or Sorbet artifacts into shared files:
+If the reference is a **Ruby app or gem** (e.g. `checkoff` or a private baked gem) and you are at the **meta** cookiecutter, do **not** port Ruby-only bootstrap or Sorbet artifacts into shared files:
 
 - `fix.sh`: rbenv `--list-all`, `set_ruby_local_version` churn, `ensure_rugged_packages_installed` (**Ruby repos only** — not generic language templates), extra `ensure_rbenv`; project-only `handlebars` / `mini_racer` / `chromedriver` helpers
 - `.gitignore`: `tapioca.installed`, `yardoc.installed`, `sorbet/machine_specific_config`
@@ -76,14 +76,15 @@ If the reference is a **Ruby app or gem** (e.g. `checkoff`, `plate-spinner`) and
 
 **Rugged** (`ensure_rugged_packages_installed`) is **Ruby-repo-specific** — add it in `cookiecutter-gem` (or the baked app), not in this meta repo’s generic language template. Details: [template-hierarchy.mdc](../../.cursor/rules/template-hierarchy.mdc), [SYNCING_BOILERPLATE.md](../../docs/SYNCING_BOILERPLATE.md).
 
-## Baked app references (e.g. `plate-spinner`)
+## Baked app references (private repos)
 
-Before copying from a **production** repo into a cookiecutter template:
+Before copying from a **production** or **private baked** repo into a cookiecutter template:
 
 1. Identify which cookiecutter tier you are editing (meta / language / nested project).
 2. Run a path-by-path diff; reject anything under `lib/`, app `config/`, or project-only `Makefile` / `Gemfile` unless this tier is meant to generate that layout.
 3. **Good ports:** `env.local` + `.envrc`, 1Password docs, `.dockerignore`, `no_output_timeout`, `config/env.local` gitignore.
 4. **Bad ports:** full reference `.overcommit.yml`, reference `.yamllint.yml` Ruby/Sorbet blocks, CircleCI debugging checkout, project native deps in `fix.sh` (see SYNCING doc).
+5. **Naming:** do not put private reference repo names in public commits, PRs, or docs.
 
 ## Quick baseline
 

--- a/{{cookiecutter.project_slug}}/.dockerignore
+++ b/{{cookiecutter.project_slug}}/.dockerignore
@@ -13,6 +13,7 @@
 
 # used for local dev only
 /config/env.1p
+/config/env.local
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/{{cookiecutter.project_slug}}/.envrc
+++ b/{{cookiecutter.project_slug}}/.envrc
@@ -6,4 +6,29 @@
 
 PATH_add bin
 
-direnv_load op run --cache --env-file=config/env.1p -- direnv dump
+watch_file config/env.1p
+watch_file config/env.local
+
+if [[ -r config/env.local ]]; then
+  if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
+    echo "config/env.local must contain resolved values, not op:// references." >&2
+    exit 1
+  fi
+  eval "$(
+    ENV_LOCAL_FILE=config/env.local ruby -rshellwords -e '
+      File.foreach(ENV.fetch("ENV_LOCAL_FILE")) do |line|
+        line = line.strip
+        next if line.empty? || line.start_with?("#")
+        key, value = line.split("=", 2)
+        next if value.nil?
+        value = value.strip
+        if value.length >= 2 && value.start_with?("\"") && value.end_with?("\"")
+          value = value[1..-2]
+        end
+        puts "export #{Shellwords.escape(key)}=#{Shellwords.escape(value)}"
+      end
+    '
+  )"
+else
+  direnv_load op run --cache --env-file=config/env.1p -- direnv dump
+fi

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -117,6 +117,9 @@ types.installed
 # Ignore bundler config.
 /.bundle/config
 
+# 1Password Environment local mount (resolved literals; template is config/env.1p)
+/config/env.local
+
 # Overcommit installs hooks here; only bootstrap post-checkout is tracked
 .githooks/*
 !.githooks/post-checkout

--- a/{{cookiecutter.project_slug}}/.overcommit.yml
+++ b/{{cookiecutter.project_slug}}/.overcommit.yml
@@ -26,6 +26,7 @@ PreCommit:
     exclude:
       # used for development
       - 'config/env.1p'
+      - 'config/env.local'
   FixMe:
     enabled: true
     exclude:
@@ -64,6 +65,7 @@ PreCommit:
       - '{% raw %}{{cookiecutter.project_slug}}{% endraw %}/**/*'
       # used for development
       - 'config/env.1p'
+      - 'config/env.local'
       # sorbet sure likes to crash
       - 'core.*'
       # don't freak out over line below

--- a/{{cookiecutter.project_slug}}/DEVELOPMENT.md
+++ b/{{cookiecutter.project_slug}}/DEVELOPMENT.md
@@ -53,6 +53,82 @@ bin/overcommit --sign pre-commit
 This project uses direnv to manage environment variables used during
 development.  See the `.envrc` file for detail.
 
+### Secrets: `config/env.1p` and 1Password
+
+`config/env.1p` in git is the **template**: each variable points at a vault
+item with an `op://` [secret
+reference](https://developer.1password.com/docs/cli/secret-reference), not a
+plaintext value.  `.envrc` and `make config/env` prefer **`config/env.local`**
+when that file is readable (1Password Environment mount with resolved
+literals); otherwise they use `op run --env-file=config/env.1p` (always in
+git) to resolve references at load time.
+
+For local development, you can also store **resolved** values in a
+[1Password Environment](https://developer.1password.com/docs/environments/) and mount
+them as a [local `.env`
+file](https://developer.1password.com/docs/environments/local-env-file/) at
+**`config/env.local`** (macOS beta; fifo mount, gitignored).  Do **not**
+mount at `config/env.1p` — that path is the tracked `op://` template and
+conflicts with git.  When vault items change or you add keys to the template,
+refresh the Environment with `op inject` and the 1Password app.
+
+#### Prerequisites (macOS)
+
+* [1Password for Mac](https://1password.com/downloads/mac/) with **Developer**
+  turned on (Settings → Developer).
+* [1Password CLI](https://developer.1password.com/docs/cli/get-started/):
+  `brew install 1password-cli`
+* Signed in: `op signin` (or 1Password app integration enabled).
+* 1Password unlocked when you run `op inject`.
+
+#### One-time: Environment and local mount
+
+1. Open 1Password → **Developer** → **View Environments**.
+2. Open (or create) the environment for this repo.
+3. Under **Destinations**, add **Local .env file** and set the path to this
+   repo’s **`config/env.local`** (use an absolute path, e.g.
+   `$PWD/config/env.local` from the repo root).
+4. Approve access when prompted; keep 1Password running while developing.
+
+| Path | Role |
+|------|------|
+| `config/env.1p` | Git-tracked template (`op://` references); fallback for `.envrc` / `make config/env` |
+| `config/env.local` | 1Password Environment mount (resolved literals); preferred when present |
+
+Do not commit `config/env.local`.
+
+#### Update the Environment from `config/env.1p` (`op inject`)
+
+Use this when you have changed `config/env.1p` in git (new variables or
+updated `op://` paths) or when secrets in 1Password vaults have changed and
+you want the Environment to match current vault values.
+
+1. From the repo root, resolve the template to a **temporary** file (never
+   write injected secrets back onto the tracked `config/env.1p`):
+
+   ```sh
+   op inject -i config/env.1p -o /tmp/repo-env.import -f
+   ```
+
+2. Confirm every reference resolved (no `op://` left):
+
+   ```sh
+   grep 'op://' /tmp/repo-env.import && echo 'ERROR: unresolved references' || echo 'OK'
+   ```
+
+3. Import into 1Password, then `rm /tmp/repo-env.import`.
+
+4. If you use a local mount at `config/env.local`, confirm
+   `grep -c op:// config/env.local` is **0**, then `direnv allow`.
+
+#### Avoid duplicate variables
+
+1Password Environments allow **multiple entries with the same name**.  The
+mounted `config/env.local` will then mix `op://` lines with resolved values,
+and `.envrc` will fail its `op://` check.  **Clean reset:** delete all
+variables in the Environment, `op inject` once, import that file, and confirm
+`grep -c op:// config/env.local` is **0**.
+
 ## Syncing boilerplate
 
 See [docs/SYNCING_BOILERPLATE.md](docs/SYNCING_BOILERPLATE.md). Skill: `.cursor/skills/apiology-boilerplate-sync/`. Rules: `boilerplate-sync.mdc`, `template-hierarchy.mdc`, `overcommit-signing.mdc` — interpret hierarchy at **this** tier (`{{ cookiecutter.project_slug }}`, {{ cookiecutter.language_or_tool }}).

--- a/{{cookiecutter.project_slug}}/docs/SYNCING_BOILERPLATE.md
+++ b/{{cookiecutter.project_slug}}/docs/SYNCING_BOILERPLATE.md
@@ -54,6 +54,20 @@ When the reference is a **Ruby application or gem** (e.g. `apiology/checkoff`) a
 
 Those belong in a **Ruby language** cookiecutter (e.g. `cookiecutter-ruby`), not the meta template. See `.cursor/rules/template-hierarchy.mdc` (meta and language tiers).
 
+### Baked Ruby apps (e.g. `apiology/plate-spinner`)
+
+`plate-spinner` was generated from `cookiecutter-gem`. When using it (or any baked gem/app) as a reference:
+
+1. **Confirm tier** — meta vs language cookiecutter vs nested project template vs “never port.”
+2. **Prefer agnostic wins** — `config/env.local`, `.envrc`, 1Password docs in `DEVELOPMENT.md`, `.dockerignore`, CircleCI `no_output_timeout`.
+3. **Skip by default** (common false positives on sync):
+   - **Overcommit / Yamllint:** RuboCop, Sorbet, Solargraph, Brakeman, Fasterer, BundleAudit, prepush Rake targets; YamlLint `sorbet/**` or `rbs_collection.lock.yaml` ignores; app-only Solargraph paths.
+   - **CircleCI:** `checkout: method: full`, `pwd` in setup, cache keys on `*.gemspec` or app-specific filenames.
+   - **`fix.sh`:** `ensure_rugged_packages_installed` (**Ruby repos only**, e.g. `cookiecutter-gem` — undercover), `ensure_handlebars_engine_packages_installed`, `ensure_mini_racer_packages_installed`, `ensure_chromedriver_correct_platform` — none of these belong in this **generic** language cookiecutter template or meta nested copies.
+   - **App tree:** `Makefile`, `Gemfile`, `lib/`, filled `config/env.1p`, `PATH_add script` when `script/` is absent here.
+
+Record `plate-spinner` `origin/main` SHA in the PR; diff with `git show origin/main:<path>` only.
+
 ### `.envrc` and `PATH_add`
 
 - Only `PATH_add` directories that **exist in this template** (typically `bin/` when `bin/` is present).

--- a/{{cookiecutter.project_slug}}/docs/SYNCING_BOILERPLATE.md
+++ b/{{cookiecutter.project_slug}}/docs/SYNCING_BOILERPLATE.md
@@ -54,9 +54,9 @@ When the reference is a **Ruby application or gem** (e.g. `apiology/checkoff`) a
 
 Those belong in a **Ruby language** cookiecutter (e.g. `cookiecutter-ruby`), not the meta template. See `.cursor/rules/template-hierarchy.mdc` (meta and language tiers).
 
-### Baked Ruby apps (e.g. `apiology/plate-spinner`)
+### Baked Ruby apps (private reference repos)
 
-`plate-spinner` was generated from `cookiecutter-gem`. When using it (or any baked gem/app) as a reference:
+A typical repo generated from `cookiecutter-gem` is a useful reference. When using any baked gem/app as a reference:
 
 1. **Confirm tier** — meta vs language cookiecutter vs nested project template vs “never port.”
 2. **Prefer agnostic wins** — `config/env.local`, `.envrc`, 1Password docs in `DEVELOPMENT.md`, `.dockerignore`, CircleCI `no_output_timeout`.
@@ -66,7 +66,7 @@ Those belong in a **Ruby language** cookiecutter (e.g. `cookiecutter-ruby`), not
    - **`fix.sh`:** `ensure_rugged_packages_installed` (**Ruby repos only**, e.g. `cookiecutter-gem` — undercover), `ensure_handlebars_engine_packages_installed`, `ensure_mini_racer_packages_installed`, `ensure_chromedriver_correct_platform` — none of these belong in this **generic** language cookiecutter template or meta nested copies.
    - **App tree:** `Makefile`, `Gemfile`, `lib/`, filled `config/env.1p`, `PATH_add script` when `script/` is absent here.
 
-Record `plate-spinner` `origin/main` SHA in the PR; diff with `git show origin/main:<path>` only.
+Record the reference repo’s `origin/main` SHA in the PR (omit the private repo name from public text); diff with `git show origin/main:<path>` only.
 
 ### `.envrc` and `PATH_add`
 

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.circleci/config.yml
@@ -15,6 +15,7 @@ commands:
     steps:
       - run:
           name: <<parameters.label>>
+          no_output_timeout: 30m
           command: |
             export PATH="${HOME}/.pyenv/bin:${PATH}"
             export PATH="${HOME}/.rbenv/bin:${HOME}/.rbenv/shims:${PATH}"

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.cursor/rules/template-hierarchy.mdc
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.cursor/rules/template-hierarchy.mdc
@@ -19,7 +19,7 @@ alwaysApply: false
 
 - If a reference repo is more specific than this template (e.g. Rails app vs Ruby repo), treat extra config as **out of scope** for this cookiecutter (or a different child template).
 - Do **not** add cookiecutter-family sync skills, `SYNCING_BOILERPLATE.md`, or pytest bake tips unless this project template is Python-specific by design.
-- From baked apps (e.g. `plate-spinner`): do **not** port reference `.overcommit.yml` Ruby hooks, Sorbet yamllint ignores, or `fix.sh` **`rugged`** (Ruby repos only, e.g. `cookiecutter-gem`) / `handlebars` / `mini_racer` / `chromedriver`. Agnostic `env.local` / `.envrc` ports are still fine when this tree has `config/env.1p`.
+- From baked private apps: do **not** port reference `.overcommit.yml` Ruby hooks, Sorbet yamllint ignores, or `fix.sh` **`rugged`** (Ruby repos only, e.g. `cookiecutter-gem`) / `handlebars` / `mini_racer` / `chromedriver`. Agnostic `env.local` / `.envrc` ports are still fine when this tree has `config/env.1p`. Do not name private reference repos in public text.
 
 ## Propagate across tiers (agent checklist)
 

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.cursor/rules/template-hierarchy.mdc
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.cursor/rules/template-hierarchy.mdc
@@ -19,6 +19,7 @@ alwaysApply: false
 
 - If a reference repo is more specific than this template (e.g. Rails app vs Ruby repo), treat extra config as **out of scope** for this cookiecutter (or a different child template).
 - Do **not** add cookiecutter-family sync skills, `SYNCING_BOILERPLATE.md`, or pytest bake tips unless this project template is Python-specific by design.
+- From baked apps (e.g. `plate-spinner`): do **not** port reference `.overcommit.yml` Ruby hooks, Sorbet yamllint ignores, or `fix.sh` **`rugged`** (Ruby repos only, e.g. `cookiecutter-gem`) / `handlebars` / `mini_racer` / `chromedriver`. Agnostic `env.local` / `.envrc` ports are still fine when this tree has `config/env.1p`.
 
 ## Propagate across tiers (agent checklist)
 

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.dockerignore
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.dockerignore
@@ -13,6 +13,7 @@
 
 # used for local dev only
 /config/env.1p
+/config/env.local
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.envrc
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.envrc
@@ -6,4 +6,29 @@
 
 PATH_add bin
 
-direnv_load op run --cache --env-file=config/env.1p -- direnv dump
+watch_file config/env.1p
+watch_file config/env.local
+
+if [[ -r config/env.local ]]; then
+  if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
+    echo "config/env.local must contain resolved values, not op:// references." >&2
+    exit 1
+  fi
+  eval "$(
+    ENV_LOCAL_FILE=config/env.local ruby -rshellwords -e '
+      File.foreach(ENV.fetch("ENV_LOCAL_FILE")) do |line|
+        line = line.strip
+        next if line.empty? || line.start_with?("#")
+        key, value = line.split("=", 2)
+        next if value.nil?
+        value = value.strip
+        if value.length >= 2 && value.start_with?("\"") && value.end_with?("\"")
+          value = value[1..-2]
+        end
+        puts "export #{Shellwords.escape(key)}=#{Shellwords.escape(value)}"
+      end
+    '
+  )"
+else
+  direnv_load op run --cache --env-file=config/env.1p -- direnv dump
+fi

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.gitignore
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.gitignore
@@ -55,6 +55,9 @@ types.installed
 # Ignore bundler config.
 /.bundle/config
 
+# 1Password Environment local mount (resolved literals; template is config/env.1p)
+/config/env.local
+
 # Overcommit installs hooks here; only bootstrap post-checkout is tracked
 .githooks/*
 !.githooks/post-checkout

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.overcommit.yml
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.overcommit.yml
@@ -26,6 +26,7 @@ PreCommit:
     exclude:
       # used for development
       - 'config/env.1p'
+      - 'config/env.local'
   FixMe:
     enabled: true
     exclude:
@@ -56,6 +57,7 @@ PreCommit:
     exclude:
       # used for development
       - 'config/env.1p'
+      - 'config/env.local'
       # sorbet sure likes to crash
       - 'core.*'
       # don't freak out over line below

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/DEVELOPMENT.md
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/DEVELOPMENT.md
@@ -52,3 +52,34 @@ bin/overcommit --sign pre-commit
 
 This project uses direnv to manage environment variables used during
 development.  See the `.envrc` file for detail.
+
+### Secrets: `config/env.1p` and 1Password
+
+`config/env.1p` in git is the **template**: each variable points at a vault
+item with an `op://` [secret
+reference](https://developer.1password.com/docs/cli/secret-reference), not a
+plaintext value.  `.envrc` and `make config/env` prefer **`config/env.local`**
+when that file is readable (1Password Environment mount with resolved
+literals); otherwise they use `op run --env-file=config/env.1p` (always in
+git) to resolve references at load time.
+
+For local development, you can also store **resolved** values in a
+[1Password Environment](https://developer.1password.com/docs/environments/) and mount
+them as a [local `.env`
+file](https://developer.1password.com/docs/environments/local-env-file/) at
+**`config/env.local`** (macOS beta; fifo mount, gitignored).  Do **not**
+mount at `config/env.1p` — that path is the tracked `op://` template and
+conflicts with git.
+
+#### Update the Environment from `config/env.1p` (`op inject`)
+
+```sh
+op inject -i config/env.1p -o /tmp/repo-env.import -f
+grep 'op://' /tmp/repo-env.import && echo 'ERROR: unresolved references' || echo 'OK'
+# Import /tmp/repo-env.import in 1Password → Environments, then:
+rm /tmp/repo-env.import
+```
+
+If you use a local mount at `config/env.local`, confirm
+`grep -c op:// config/env.local` is **0**, then `direnv allow`.  Do not
+commit `config/env.local`.


### PR DESCRIPTION
## Summary

- Add **`config/env.local`** support in `.envrc` at meta, language, and nested project tiers (prefer a resolved 1Password Environment mount; fall back to `op run` on `config/env.1p`).
- Document the 1Password / `env.local` workflow in `DEVELOPMENT.md`; extend `SYNCING_BOILERPLATE.md`, `template-hierarchy.mdc`, and `apiology-boilerplate-sync` with guidance for syncing from baked Ruby apps without copying Ruby-only Overcommit hooks, `fix.sh` project deps, or private repo names into public template text.
- Scrub private reference app names from sync docs and rules (naming policy is a **user** Cursor rule only, not committed in this repo).
- Set CircleCI **`no_output_timeout: 30m`** on long run steps; ignore `config/env.local` in `.dockerignore` / `.gitignore` / Overcommit BrokenSymlinks and Punchlist.

## Test plan

- [ ] `pytest tests/test_bake_project.py` (or project CI) on this branch
- [ ] Fresh clone: `./fix.sh` and `direnv allow` with only `config/env.1p`; with `config/env.local` containing resolved values
- [ ] Confirm Overcommit pre-commit passes after `bin/overcommit --sign` if config changed