### PR TITLE
Bump overcommit to 0.69.0 (checkoff boilerplate sync)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,6 @@ group :development, :test do
 end
 
 group :development do
-  gem 'overcommit', '~>0.68.0'
+  gem 'overcommit', '~>0.69.0'
   gem 'punchlist', ['>=1.3.1']
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,13 +23,13 @@ GEM
       tomlrb
     mixlib-shellout (3.3.9)
       chef-utils
-    overcommit (0.68.0)
+    overcommit (0.69.0)
       childprocess (>= 0.6.3, < 6)
       iniparse (~> 1.4)
       rexml (>= 3.3.9)
     punchlist (1.3.2)
       source_finder (>= 2)
-    rexml (3.4.1)
+    rexml (3.4.4)
     source_finder (3.2.1)
     tomlrb (2.0.3)
 
@@ -39,7 +39,7 @@ PLATFORMS
 
 DEPENDENCIES
   mdl
-  overcommit (~> 0.68.0)
+  overcommit (~> 0.69.0)
   punchlist (>= 1.3.1)
 
 BUNDLED WITH

--- a/{{cookiecutter.project_slug}}/Gemfile
+++ b/{{cookiecutter.project_slug}}/Gemfile
@@ -7,6 +7,6 @@ group :development, :test do
 end
 
 group :development do
-  gem 'overcommit', '~>0.68.0'
+  gem 'overcommit', '~>0.69.0'
   gem 'punchlist', ['>=1.3.1']
 end

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/Gemfile
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/Gemfile
@@ -7,6 +7,6 @@ group :development, :test do
 end
 
 group :development do
-  gem 'overcommit', '~>0.68.0'
+  gem 'overcommit', '~>0.69.0'
   gem 'punchlist', ['>=1.3.1']
 end


### PR DESCRIPTION
## Summary

- Bump `overcommit` from `~>0.68.0` to `~>0.69.0` at meta, language/tool, and nested project template tiers.
- Refresh root `Gemfile.lock` (includes incidental `rexml` 3.4.4).
- Boilerplate sync from `apiology/checkoff` `origin/main` @ `b593b69`; no Ruby/app-specific ports (CircleCI checkout, RuboCop stack, `fix.sh` rbenv changes).

## Test plan

- [x] `pytest` (1 passed locally)
- [ ] CI green on draft PR


Made with [Cursor](https://cursor.com)