### PR TITLE
Sync fix.sh rbenv updates and git-hook typing from reference repo

### DIFF
--- a/.git-hooks/pre_commit/circle_ci.rb
+++ b/.git-hooks/pre_commit/circle_ci.rb
@@ -11,6 +11,7 @@ module Overcommit
       class CircleCi < Base
         # @return [Symbol, Array<Symbol, String>]
         def run
+          # @type [Overcommit::Subprocess::Result]
           result = execute(command)
           return :pass if result.success?
 

--- a/.git-hooks/pre_commit/punchlist.rb
+++ b/.git-hooks/pre_commit/punchlist.rb
@@ -12,6 +12,7 @@ module Overcommit
       class Punchlist < Base
         # @param stdout [String]
         # @return [Array<Overcommit::Hook::Message>]
+        # @sg-ignore Message.new inferred as Punchlist in this hook class
         def parse_output(stdout)
           stdout.split("\n").map do |line|
             file, line_no, _message = line.split(':', 3)

--- a/fix.sh
+++ b/fix.sh
@@ -89,7 +89,9 @@ latest_ruby_version() {
   #
   # https://github.com/rbenv/rbenv/issues/1441
   set +e
-  rbenv install --list 2>/dev/null | cat | grep "^${major_minor}."
+  # ruby-build 202605+ dropped EOL Rubies from `--list`; use `--list-all`.
+  # Match only patch releases, not prereleases (preview/rc/dev).
+  rbenv install --list-all 2>/dev/null | grep "^${major_minor}\\." | grep -v -- -preview | grep -v -- -rc | grep -v -- -dev | tail -1
   set -e
 }
 
@@ -246,6 +248,7 @@ set_ruby_local_version() {
   then
     echo "${latest_ruby_version}" > .ruby-version
   fi
+  set_rbenv_env_variables
 }
 
 latest_python_version() {
@@ -446,6 +449,8 @@ ensure_overcommit() {
     >&2 echo 'Not in a git repo; not installing git hooks'
   fi
 }
+
+ensure_rbenv
 
 ensure_types_built() {
   make build-typecheck

--- a/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/circle_ci.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/circle_ci.rb
@@ -11,6 +11,7 @@ module Overcommit
       class CircleCi < Base
         # @return [Symbol, Array<Symbol, String>]
         def run
+          # @type [Overcommit::Subprocess::Result]
           result = execute(command)
           return :pass if result.success?
 

--- a/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/punchlist.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/punchlist.rb
@@ -12,6 +12,7 @@ module Overcommit
       class Punchlist < Base
         # @param stdout [String]
         # @return [Array<Overcommit::Hook::Message>]
+        # @sg-ignore Message.new inferred as Punchlist in this hook class
         def parse_output(stdout)
           stdout.split("\n").map do |line|
             file, line_no, _message = line.split(':', 3)

--- a/{{cookiecutter.project_slug}}/fix.sh
+++ b/{{cookiecutter.project_slug}}/fix.sh
@@ -89,7 +89,9 @@ latest_ruby_version() {
   #
   # https://github.com/rbenv/rbenv/issues/1441
   set +e
-  rbenv install --list 2>/dev/null | cat | grep "^${major_minor}."
+  # ruby-build 202605+ dropped EOL Rubies from `--list`; use `--list-all`.
+  # Match only patch releases, not prereleases (preview/rc/dev).
+  rbenv install --list-all 2>/dev/null | grep "^${major_minor}\\." | grep -v -- -preview | grep -v -- -rc | grep -v -- -dev | tail -1
   set -e
 }
 
@@ -246,6 +248,7 @@ set_ruby_local_version() {
   then
     echo "${latest_ruby_version}" > .ruby-version
   fi
+  set_rbenv_env_variables
 }
 
 latest_python_version() {
@@ -446,6 +449,8 @@ ensure_overcommit() {
     >&2 echo 'Not in a git repo; not installing git hooks'
   fi
 }
+
+ensure_rbenv
 
 ensure_types_built() {
   make build-typecheck

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.git-hooks/pre_commit/circle_ci.rb
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.git-hooks/pre_commit/circle_ci.rb
@@ -11,6 +11,7 @@ module Overcommit
       class CircleCi < Base
         # @return [Symbol, Array<Symbol, String>]
         def run
+          # @type [Overcommit::Subprocess::Result]
           result = execute(command)
           return :pass if result.success?
 

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.git-hooks/pre_commit/punchlist.rb
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.git-hooks/pre_commit/punchlist.rb
@@ -12,6 +12,7 @@ module Overcommit
       class Punchlist < Base
         # @param stdout [String]
         # @return [Array<Overcommit::Hook::Message>]
+        # @sg-ignore Message.new inferred as Punchlist in this hook class
         def parse_output(stdout)
           stdout.split("\n").map do |line|
             file, line_no, _message = line.split(':', 3)

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/fix.sh
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/fix.sh
@@ -89,7 +89,9 @@ latest_ruby_version() {
   #
   # https://github.com/rbenv/rbenv/issues/1441
   set +e
-  rbenv install --list 2>/dev/null | cat | grep "^${major_minor}."
+  # ruby-build 202605+ dropped EOL Rubies from `--list`; use `--list-all`.
+  # Match only patch releases, not prereleases (preview/rc/dev).
+  rbenv install --list-all 2>/dev/null | grep "^${major_minor}\\." | grep -v -- -preview | grep -v -- -rc | grep -v -- -dev | tail -1
   set -e
 }
 
@@ -241,6 +243,7 @@ set_ruby_local_version() {
   then
     echo "${latest_ruby_version}" > .ruby-version
   fi
+  set_rbenv_env_variables
 }
 
 latest_python_version() {
@@ -441,6 +444,8 @@ ensure_overcommit() {
     >&2 echo 'Not in a git repo; not installing git hooks'
   fi
 }
+
+ensure_rbenv
 
 ensure_types_built() {
   make build-typecheck


### PR DESCRIPTION
## Summary
- Port `fix.sh` rbenv improvements from reference repo `origin/main` 8861f67 at all three template tiers: `rbenv install --list-all` with prerelease filtering, `set_rbenv_env_variables` in `set_ruby_local_version`, and an early `ensure_rbenv` call.
- Add Sorbet typing annotations to `.git-hooks/pre_commit/circle_ci.rb` and `punchlist.rb` at each tier.
- Intentionally omitted: `ensure_rugged_packages_installed`, Makefile/Sorbet targets, `set_ruby_local_version` `tail -1`, and Python 3.12-only pyenv pinning.

## Test plan
- [x] `pytest`
- [ ] `./fix.sh` on a fresh clone (rbenv/ruby-build path)
- [ ] `bin/overcommit --run` with updated hook files


Made with [Cursor](https://cursor.com)