### PR TITLE
Run post-checkout fix.sh through direnv

### DIFF
--- a/.cursor/rules/overcommit-signing.mdc
+++ b/.cursor/rules/overcommit-signing.mdc
@@ -2,8 +2,9 @@
 description: >-
   When git commit fails with overcommit plugin signature or security messages,
   run bin/overcommit --sign and bin/overcommit --sign pre-commit, then retry.
-  In a fresh worktree, ./fix.sh should run automatically via .githooks/post-checkout
-  when core.hooksPath is set; if not, run ./fix.sh so .ruby-version pins the same
+  In a fresh worktree, direnv exec . ./fix.sh should run automatically via
+  .githooks/post-checkout when core.hooksPath is set; if not, run it manually so
+  .ruby-version pins the same
   Ruby the git hook will use — overcommit plugin signatures are not stable
   across Ruby versions.
 alwaysApply: false
@@ -23,9 +24,10 @@ Run **both** sign commands every time — not only one. Do not use `--no-verify`
 
 ## Worktrees: pin Ruby first
 
-After `git worktree add`, `.githooks/post-checkout` runs `./fix.sh` automatically
-when the repo already has `core.hooksPath` set (via a prior `./fix.sh` on the main
-checkout). If the hook did not run, run `./fix.sh` manually in the new worktree.
+After `git worktree add`, `.githooks/post-checkout` runs `direnv exec . ./fix.sh`
+automatically when the repo already has `core.hooksPath` set (via a prior bootstrap
+on the main checkout). If the hook did not run, run `direnv exec . ./fix.sh`
+manually in the new worktree (or `./fix.sh` when there is no `.envrc`).
 `fix.sh` writes `.ruby-version` (gitignored) so rbenv pins the same Ruby in the
 worktree as in the main checkout.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,8 +16,9 @@ bootstrap hooks apply to this repo and all its worktrees.
 ## Git hooks and worktrees
 
 Bootstrap hooks live in `.githooks/` (plain bash, not Overcommit) so
-`post-checkout` can run `./fix.sh` on clone or `git worktree add` before
-Ruby and Bundler are ready.
+`post-checkout` can run `direnv exec . ./fix.sh` on clone or
+`git worktree add` before Ruby and Bundler are ready. `fix.sh` uses
+helpers under `bin/`; direnv (via `.envrc`) puts `bin/` on `PATH`.
 
 For a fresh clone with automatic bootstrap on checkout:
 
@@ -25,12 +26,13 @@ For a fresh clone with automatic bootstrap on checkout:
 git clone -c core.hooksPath=.githooks <url>
 ```
 
-Otherwise run `./fix.sh` once after clone — it sets `core.hooksPath` for
-future worktrees.
+Otherwise run `direnv exec . ./fix.sh` once after clone (or `./fix.sh` if
+you have no `.envrc`) — it sets `core.hooksPath` for future worktrees.
 
-After `git worktree add`, `.githooks/post-checkout` runs `./fix.sh`
-automatically when the main checkout has already run `./fix.sh` at least
-once. It writes `.ruby-version` (gitignored) and runs `bundle install`,
+After `git worktree add`, `.githooks/post-checkout` runs
+`direnv exec . ./fix.sh` automatically when the main checkout has already
+run bootstrap at least once. It writes `.ruby-version` (gitignored) and
+runs `bundle install`,
 so the worktree's Ruby and bundler match the main checkout. Skipping
 bootstrap can cause overcommit signature mismatches even after
 re-signing — see

--- a/bin/git-post-checkout-fix
+++ b/bin/git-post-checkout-fix
@@ -13,4 +13,9 @@ if [ "${branch_checkout}" != '1' ] || [ "${prev_head}" != "${NULL_REF}" ]; then
   exit 0
 fi
 
+# fix.sh calls bin/* helpers; .envrc (via direnv) adds bin/ to PATH.
+if [ -f .envrc ] && command -v direnv >/dev/null 2>&1; then
+  exec direnv exec . ./fix.sh
+fi
+
 exec ./fix.sh

--- a/{{cookiecutter.project_slug}}/.cursor/rules/overcommit-signing.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/overcommit-signing.mdc
@@ -2,8 +2,9 @@
 description: >-
   When git commit fails with overcommit plugin signature or security messages,
   run bin/overcommit --sign and bin/overcommit --sign pre-commit, then retry.
-  In a fresh worktree, ./fix.sh should run automatically via .githooks/post-checkout
-  when core.hooksPath is set; if not, run ./fix.sh so .ruby-version pins the same
+  In a fresh worktree, direnv exec . ./fix.sh should run automatically via
+  .githooks/post-checkout when core.hooksPath is set; if not, run it manually so
+  .ruby-version pins the same
   Ruby the git hook will use — overcommit plugin signatures are not stable
   across Ruby versions.
 alwaysApply: false
@@ -23,9 +24,10 @@ Run **both** sign commands every time — not only one. Do not use `--no-verify`
 
 ## Worktrees: pin Ruby first
 
-After `git worktree add`, `.githooks/post-checkout` runs `./fix.sh` automatically
-when the repo already has `core.hooksPath` set (via a prior `./fix.sh` on the main
-checkout). If the hook did not run, run `./fix.sh` manually in the new worktree.
+After `git worktree add`, `.githooks/post-checkout` runs `direnv exec . ./fix.sh`
+automatically when the repo already has `core.hooksPath` set (via a prior bootstrap
+on the main checkout). If the hook did not run, run `direnv exec . ./fix.sh`
+manually in the new worktree (or `./fix.sh` when there is no `.envrc`).
 `fix.sh` writes `.ruby-version` (gitignored) so rbenv pins the same Ruby in the
 worktree as in the main checkout.
 

--- a/{{cookiecutter.project_slug}}/DEVELOPMENT.md
+++ b/{{cookiecutter.project_slug}}/DEVELOPMENT.md
@@ -10,8 +10,9 @@ bootstrap hooks apply to this repo and all its worktrees.
 ## Git hooks and worktrees
 
 Bootstrap hooks live in `.githooks/` (plain bash, not Overcommit) so
-`post-checkout` can run `./fix.sh` on clone or `git worktree add` before
-Ruby and Bundler are ready.
+`post-checkout` can run `direnv exec . ./fix.sh` on clone or
+`git worktree add` before Ruby and Bundler are ready. `fix.sh` uses
+helpers under `bin/`; direnv (via `.envrc`) puts `bin/` on `PATH`.
 
 For a fresh clone with automatic bootstrap on checkout:
 
@@ -19,12 +20,13 @@ For a fresh clone with automatic bootstrap on checkout:
 git clone -c core.hooksPath=.githooks <url>
 ```
 
-Otherwise run `./fix.sh` once after clone — it sets `core.hooksPath` for
-future worktrees.
+Otherwise run `direnv exec . ./fix.sh` once after clone (or `./fix.sh` if
+you have no `.envrc`) — it sets `core.hooksPath` for future worktrees.
 
-After `git worktree add`, `.githooks/post-checkout` runs `./fix.sh`
-automatically when the main checkout has already run `./fix.sh` at least
-once. It writes `.ruby-version` (gitignored) and runs `bundle install`,
+After `git worktree add`, `.githooks/post-checkout` runs
+`direnv exec . ./fix.sh` automatically when the main checkout has already
+run bootstrap at least once. It writes `.ruby-version` (gitignored) and
+runs `bundle install`,
 so the worktree's Ruby and bundler match the main checkout. Skipping
 bootstrap can cause overcommit signature mismatches even after
 re-signing — see

--- a/{{cookiecutter.project_slug}}/bin/git-post-checkout-fix
+++ b/{{cookiecutter.project_slug}}/bin/git-post-checkout-fix
@@ -13,4 +13,9 @@ if [ "${branch_checkout}" != '1' ] || [ "${prev_head}" != "${NULL_REF}" ]; then
   exit 0
 fi
 
+# fix.sh calls bin/* helpers; .envrc (via direnv) adds bin/ to PATH.
+if [ -f .envrc ] && command -v direnv >/dev/null 2>&1; then
+  exec direnv exec . ./fix.sh
+fi
+
 exec ./fix.sh

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.cursor/rules/overcommit-signing.mdc
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.cursor/rules/overcommit-signing.mdc
@@ -2,8 +2,9 @@
 description: >-
   When git commit fails with overcommit plugin signature or security messages,
   run bin/overcommit --sign and bin/overcommit --sign pre-commit, then retry.
-  In a fresh worktree, ./fix.sh should run automatically via .githooks/post-checkout
-  when core.hooksPath is set; if not, run ./fix.sh so .ruby-version pins the same
+  In a fresh worktree, direnv exec . ./fix.sh should run automatically via
+  .githooks/post-checkout when core.hooksPath is set; if not, run it manually so
+  .ruby-version pins the same
   Ruby the git hook will use — overcommit plugin signatures are not stable
   across Ruby versions.
 alwaysApply: false
@@ -23,9 +24,10 @@ Run **both** sign commands every time — not only one. Do not use `--no-verify`
 
 ## Worktrees: pin Ruby first
 
-After `git worktree add`, `.githooks/post-checkout` runs `./fix.sh` automatically
-when the repo already has `core.hooksPath` set (via a prior `./fix.sh` on the main
-checkout). If the hook did not run, run `./fix.sh` manually in the new worktree.
+After `git worktree add`, `.githooks/post-checkout` runs `direnv exec . ./fix.sh`
+automatically when the repo already has `core.hooksPath` set (via a prior bootstrap
+on the main checkout). If the hook did not run, run `direnv exec . ./fix.sh`
+manually in the new worktree (or `./fix.sh` when there is no `.envrc`).
 `fix.sh` writes `.ruby-version` (gitignored) so rbenv pins the same Ruby in the
 worktree as in the main checkout.
 

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/DEVELOPMENT.md
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/DEVELOPMENT.md
@@ -10,8 +10,9 @@ bootstrap hooks apply to this repo and all its worktrees.
 ## Git hooks and worktrees
 
 Bootstrap hooks live in `.githooks/` (plain bash, not Overcommit) so
-`post-checkout` can run `./fix.sh` on clone or `git worktree add` before
-Ruby and Bundler are ready.
+`post-checkout` can run `direnv exec . ./fix.sh` on clone or
+`git worktree add` before Ruby and Bundler are ready. `fix.sh` uses
+helpers under `bin/`; direnv (via `.envrc`) puts `bin/` on `PATH`.
 
 For a fresh clone with automatic bootstrap on checkout:
 
@@ -19,12 +20,13 @@ For a fresh clone with automatic bootstrap on checkout:
 git clone -c core.hooksPath=.githooks <url>
 ```
 
-Otherwise run `./fix.sh` once after clone — it sets `core.hooksPath` for
-future worktrees.
+Otherwise run `direnv exec . ./fix.sh` once after clone (or `./fix.sh` if
+you have no `.envrc`) — it sets `core.hooksPath` for future worktrees.
 
-After `git worktree add`, `.githooks/post-checkout` runs `./fix.sh`
-automatically when the main checkout has already run `./fix.sh` at least
-once. It writes `.ruby-version` (gitignored) and runs `bundle install`,
+After `git worktree add`, `.githooks/post-checkout` runs
+`direnv exec . ./fix.sh` automatically when the main checkout has already
+run bootstrap at least once. It writes `.ruby-version` (gitignored) and
+runs `bundle install`,
 so the worktree's Ruby and bundler match the main checkout. Skipping
 bootstrap can cause overcommit signature mismatches even after
 re-signing — see

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/bin/git-post-checkout-fix
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/bin/git-post-checkout-fix
@@ -13,4 +13,9 @@ if [ "${branch_checkout}" != '1' ] || [ "${prev_head}" != "${NULL_REF}" ]; then
   exit 0
 fi
 
+# fix.sh calls bin/* helpers; .envrc (via direnv) adds bin/ to PATH.
+if [ -f .envrc ] && command -v direnv >/dev/null 2>&1; then
+  exec direnv exec . ./fix.sh
+fi
+
 exec ./fix.sh


### PR DESCRIPTION
## Summary

- `bin/git-post-checkout-fix` runs `direnv exec . ./fix.sh` when `.envrc` exists so `bin/` helpers are on `PATH` during clone/worktree bootstrap (plain `./fix.sh` does not load direnv).
- Falls back to `./fix.sh` when there is no `.envrc` or `direnv` is unavailable.
- Documents the behavior in `DEVELOPMENT.md` and `overcommit-signing.mdc` at all three template tiers (meta, language, nested project).

## Test plan

- [ ] `git worktree add` in a repo with `.envrc` and `core.hooksPath=.githooks` runs `fix.sh` successfully (no missing `bin/install_package` errors).
- [ ] Manual run: `direnv exec . ./fix.sh` from repo root succeeds.
- [ ] After merge, propagate via `update_from_cookiecutter` on baked apps (e.g. checkoff PR #450).
