### PR TITLE
Harden update_from_cookiecutter for git worktrees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,12 +166,54 @@ cicoverage: citest ## check code coverage
 update_from_cookiecutter: ## Bring in changes from template project used to create this repo
 	bin/overcommit --uninstall
 	cookiecutter_project_upgrader --help >/dev/null
-	IN_COOKIECUTTER_PROJECT_UPGRADER=1 cookiecutter_project_upgrader || true
-	IN_COOKIECUTTER_PROJECT_UPGRADER=1 cookiecutter_project_upgrader || true
+	@mkdir -p .make
+	@if [ -f docs/cookiecutter_input.json ]; then \
+	  jq 'del(._output_dir, ._repo_dir, ._checkout)' docs/cookiecutter_input.json > .make/cookiecutter_context.json; \
+	fi
+	@MAIN_REPO_ROOT=$$(dirname "$$(git rev-parse --git-common-dir)"); \
+	if [ -f "$$MAIN_REPO_ROOT/rbs_collection.yaml" ]; then \
+	  mv "$$MAIN_REPO_ROOT/rbs_collection.yaml" .make/rbs_collection.yaml.bak; \
+	  touch .make/rbs_collection_yaml_hidden; \
+	fi; \
+	if [ -f "$$MAIN_REPO_ROOT/.rubocop.yml" ]; then \
+	  mv "$$MAIN_REPO_ROOT/.rubocop.yml" .make/rubocop-main.yml.bak; \
+	  touch .make/rubocop_main_hidden; \
+	fi; \
+	if [ -f .git ] && [ ! -L .git ]; then \
+	  cp .git .make/git-worktree-pointer; \
+	  GIT_DIR=$$(git rev-parse --git-dir); \
+	  rm -f .git; \
+	  ln -s "$$GIT_DIR" .git; \
+	fi; \
+	if [ -f .make/cookiecutter_context.json ]; then \
+	  IN_COOKIECUTTER_PROJECT_UPGRADER=1 cookiecutter_project_upgrader -c .make/cookiecutter_context.json -p true || true; \
+	else \
+	  IN_COOKIECUTTER_PROJECT_UPGRADER=1 cookiecutter_project_upgrader || true; \
+	fi; \
+	if [ -f .make/git-worktree-pointer ]; then \
+	  rm -f .git; \
+	  mv .make/git-worktree-pointer .git; \
+	fi; \
+	if [ -f .make/rbs_collection_yaml_hidden ]; then \
+	  mv .make/rbs_collection.yaml.bak "$$MAIN_REPO_ROOT/rbs_collection.yaml"; \
+	  rm -f .make/rbs_collection_yaml_hidden; \
+	fi; \
+	if [ -f .make/rubocop_main_hidden ]; then \
+	  mv .make/rubocop-main.yml.bak "$$MAIN_REPO_ROOT/.rubocop.yml"; \
+	  rm -f .make/rubocop_main_hidden; \
+	fi
+	@if ! git diff --quiet -- Makefile 2>/dev/null || ! git diff --cached --quiet -- Makefile 2>/dev/null; then \
+	  git stash push -m 'update_from_cookiecutter Makefile' -- Makefile; \
+	  touch .make/cookiecutter_makefile_stashed; \
+	fi
 	git checkout cookiecutter-template && git push --no-verify
 	git checkout main; overcommit --sign && overcommit --sign pre-commit && overcommit --sign pre-push && git checkout main && git pull && git checkout -b update-from-cookiecutter-$$(date +%Y-%m-%d-%H%M)
 	git merge cookiecutter-template || true
 	git checkout --ours Gemfile.lock || true
+	@if [ -f .make/cookiecutter_makefile_stashed ]; then \
+	  git stash pop; \
+	  rm -f .make/cookiecutter_makefile_stashed; \
+	fi
 	# update frequently security-flagged gems while we're here
 	bundle update --conservative json rexml || true
 	( make build && git add Gemfile.lock ) || true

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -166,11 +166,54 @@ cicoverage: citest ## check code coverage
 update_from_cookiecutter: ## Bring in changes from template project used to create this repo
 	bin/overcommit --uninstall
 	cookiecutter_project_upgrader --help >/dev/null
-	IN_COOKIECUTTER_PROJECT_UPGRADER=1 cookiecutter_project_upgrader || true
+	@mkdir -p .make
+	@if [ -f docs/cookiecutter_input.json ]; then \
+	  jq 'del(._output_dir, ._repo_dir, ._checkout)' docs/cookiecutter_input.json > .make/cookiecutter_context.json; \
+	fi
+	@MAIN_REPO_ROOT=$$(dirname "$$(git rev-parse --git-common-dir)"); \
+	if [ -f "$$MAIN_REPO_ROOT/rbs_collection.yaml" ]; then \
+	  mv "$$MAIN_REPO_ROOT/rbs_collection.yaml" .make/rbs_collection.yaml.bak; \
+	  touch .make/rbs_collection_yaml_hidden; \
+	fi; \
+	if [ -f "$$MAIN_REPO_ROOT/.rubocop.yml" ]; then \
+	  mv "$$MAIN_REPO_ROOT/.rubocop.yml" .make/rubocop-main.yml.bak; \
+	  touch .make/rubocop_main_hidden; \
+	fi; \
+	if [ -f .git ] && [ ! -L .git ]; then \
+	  cp .git .make/git-worktree-pointer; \
+	  GIT_DIR=$$(git rev-parse --git-dir); \
+	  rm -f .git; \
+	  ln -s "$$GIT_DIR" .git; \
+	fi; \
+	if [ -f .make/cookiecutter_context.json ]; then \
+	  IN_COOKIECUTTER_PROJECT_UPGRADER=1 cookiecutter_project_upgrader -c .make/cookiecutter_context.json -p true || true; \
+	else \
+	  IN_COOKIECUTTER_PROJECT_UPGRADER=1 cookiecutter_project_upgrader || true; \
+	fi; \
+	if [ -f .make/git-worktree-pointer ]; then \
+	  rm -f .git; \
+	  mv .make/git-worktree-pointer .git; \
+	fi; \
+	if [ -f .make/rbs_collection_yaml_hidden ]; then \
+	  mv .make/rbs_collection.yaml.bak "$$MAIN_REPO_ROOT/rbs_collection.yaml"; \
+	  rm -f .make/rbs_collection_yaml_hidden; \
+	fi; \
+	if [ -f .make/rubocop_main_hidden ]; then \
+	  mv .make/rubocop-main.yml.bak "$$MAIN_REPO_ROOT/.rubocop.yml"; \
+	  rm -f .make/rubocop_main_hidden; \
+	fi
+	@if ! git diff --quiet -- Makefile 2>/dev/null || ! git diff --cached --quiet -- Makefile 2>/dev/null; then \
+	  git stash push -m 'update_from_cookiecutter Makefile' -- Makefile; \
+	  touch .make/cookiecutter_makefile_stashed; \
+	fi
 	git checkout cookiecutter-template && git push --no-verify
 	git checkout main; overcommit --sign && overcommit --sign pre-commit && overcommit --sign pre-push && git checkout main && git pull && git checkout -b update-from-cookiecutter-$$(date +%Y-%m-%d-%H%M)
 	git merge cookiecutter-template || true
 	git checkout --ours Gemfile.lock || true
+	@if [ -f .make/cookiecutter_makefile_stashed ]; then \
+	  git stash pop; \
+	  rm -f .make/cookiecutter_makefile_stashed; \
+	fi
 	# update frequently security-flagged gems while we're here
 	bundle update --conservative json rexml || true
 	( make build && git add Gemfile.lock ) || true

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/Makefile
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/Makefile
@@ -81,7 +81,7 @@ gem_dependencies: .bundle/config
 Gemfile.lock.installed: Gemfile vendor/.keep
 	touch Gemfile.lock.installed
 
-vendor/.keep: Gemfile.lock .ruby-version
+vendor/.keep: Gemfile.lock
 	make gem_dependencies
 	bundle install
 	touch vendor/.keep
@@ -127,12 +127,61 @@ cicoverage: citest report-coverage-to-codecov ## check code coverage
 
 update_from_cookiecutter: ## Bring in changes from template project used to create this repo
 	bin/overcommit --uninstall
+	# cookiecutter_project_upgrader does its work in
+	# .git/cookiecutter/{{cookiecutter.project_slug}}, but RuboCop wants to inherit
+	# config from all directories above it - avoid config
+	# mismatches by moving this out of the way
+	mv .rubocop.yml .rubocop-renamed.yml || true
 	cookiecutter_project_upgrader --help >/dev/null
-	IN_COOKIECUTTER_PROJECT_UPGRADER=1 cookiecutter_project_upgrader || true
+	@mkdir -p .make
+	@if [ -f docs/cookiecutter_input.json ]; then \
+	  jq 'del(._output_dir, ._repo_dir, ._checkout)' docs/cookiecutter_input.json > .make/cookiecutter_context.json; \
+	fi
+	@MAIN_REPO_ROOT=$$(dirname "$$(git rev-parse --git-common-dir)"); \
+	if [ -f "$$MAIN_REPO_ROOT/rbs_collection.yaml" ]; then \
+	  mv "$$MAIN_REPO_ROOT/rbs_collection.yaml" .make/rbs_collection.yaml.bak; \
+	  touch .make/rbs_collection_yaml_hidden; \
+	fi; \
+	if [ -f "$$MAIN_REPO_ROOT/.rubocop.yml" ]; then \
+	  mv "$$MAIN_REPO_ROOT/.rubocop.yml" .make/rubocop-main.yml.bak; \
+	  touch .make/rubocop_main_hidden; \
+	fi; \
+	if [ -f .git ] && [ ! -L .git ]; then \
+	  cp .git .make/git-worktree-pointer; \
+	  GIT_DIR=$$(git rev-parse --git-dir); \
+	  rm -f .git; \
+	  ln -s "$$GIT_DIR" .git; \
+	fi; \
+	if [ -f .make/cookiecutter_context.json ]; then \
+	  IN_COOKIECUTTER_PROJECT_UPGRADER=1 cookiecutter_project_upgrader -c .make/cookiecutter_context.json -p true || true; \
+	else \
+	  IN_COOKIECUTTER_PROJECT_UPGRADER=1 cookiecutter_project_upgrader || true; \
+	fi; \
+	if [ -f .make/git-worktree-pointer ]; then \
+	  rm -f .git; \
+	  mv .make/git-worktree-pointer .git; \
+	fi; \
+	if [ -f .make/rbs_collection_yaml_hidden ]; then \
+	  mv .make/rbs_collection.yaml.bak "$$MAIN_REPO_ROOT/rbs_collection.yaml"; \
+	  rm -f .make/rbs_collection_yaml_hidden; \
+	fi; \
+	if [ -f .make/rubocop_main_hidden ]; then \
+	  mv .make/rubocop-main.yml.bak "$$MAIN_REPO_ROOT/.rubocop.yml"; \
+	  rm -f .make/rubocop_main_hidden; \
+	fi
+	mv .rubocop-renamed.yml .rubocop.yml
+	@if ! git diff --quiet -- Makefile 2>/dev/null || ! git diff --cached --quiet -- Makefile 2>/dev/null; then \
+	  git stash push -m 'update_from_cookiecutter Makefile' -- Makefile; \
+	  touch .make/cookiecutter_makefile_stashed; \
+	fi
 	git checkout cookiecutter-template && git push --no-verify
 	git checkout main; overcommit --sign && overcommit --sign pre-commit && overcommit --sign pre-push && git checkout main && git pull && git checkout -b update-from-cookiecutter-$$(date +%Y-%m-%d-%H%M)
 	git merge cookiecutter-template || true
 	git checkout --ours Gemfile.lock || true
+	@if [ -f .make/cookiecutter_makefile_stashed ]; then \
+	  git stash pop; \
+	  rm -f .make/cookiecutter_makefile_stashed; \
+	fi
 	# update frequently security-flagged gems while we're here
 	bundle update --conservative json rexml || true
 	( make build && git add Gemfile.lock ) || true


### PR DESCRIPTION
## Summary

- `update_from_cookiecutter` at meta, language, and nested project tiers now supports linked git worktrees by temporarily symlinking `.git` to the real git dir for `cookiecutter_project_upgrader`.
- Stashes local `Makefile` edits before checking out `cookiecutter-template`, then restores them after merge.
- When `docs/cookiecutter_input.json` exists, strips stale cookiecutter context paths and passes `-c` / `-p true` to the upgrader; hides main-repo `rbs_collection.yaml` and `.rubocop.yml` when present (monorepo/worktree layouts).
- Nested tier also renames local `.rubocop.yml` during the upgrader run and drops `.ruby-version` from the `vendor/.keep` prerequisite so builds work when `.ruby-version` is gitignored.

## Test plan

- [ ] In a linked worktree, `make update_from_cookiecutter` completes the upgrader step without `.git/cookiecutter` errors.
- [ ] With local `Makefile` edits, the target stashes and restores them around the template branch checkout.
- [ ] Meta/language tiers without `docs/cookiecutter_input.json` still run the upgrader (fallback path).
- [ ] Nested baked layout: `make build` succeeds in a worktree without a tracked `.ruby-version`.


Made with [Cursor](https://cursor.com)