### PR TITLE
Skip op run when env.local is mounted or env.1p is empty

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,7 @@
 # shellcheck shell=bash
 #
-# Local dev: loads secrets from 1Password via config/env.1p.
+# Local dev: secrets from config/env.local (1Password Environment mount) or,
+# when env.local is absent, op run on config/env.1p only if that file has keys.
 # Cursor / other agents: this is NOT permission to run `op` or `direnv_load` here.
 # Ask the user explicitly before any 1Password CLI use in chat.
 
@@ -29,6 +30,6 @@ if [[ -r config/env.local ]]; then
       end
     '
   )"
-else
+elif [[ -r config/env.1p ]] && grep -qE '^[A-Z][A-Z0-9_]*=' config/env.1p 2>/dev/null; then
   direnv_load op run --cache --env-file=config/env.1p -- direnv dump
 fi

--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,5 @@
 # shellcheck shell=bash
 #
-# Local dev: secrets from config/env.local (1Password Environment mount) or,
-# when env.local is absent, op run on config/env.1p only if that file has keys.
 # Cursor / other agents: this is NOT permission to run `op` or `direnv_load` here.
 # Ask the user explicitly before any 1Password CLI use in chat.
 
@@ -11,10 +9,12 @@ watch_file config/env.1p
 watch_file config/env.local
 
 if [[ -r config/env.local ]]; then
+  # Load from mounted Environment file (empty mount => no secrets).
   if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
     echo "config/env.local must contain resolved values, not op:// references." >&2
     exit 1
   fi
+  # Parse KEY=value lines into exports (quoted values unwrapped).
   eval "$(
     ENV_LOCAL_FILE=config/env.local ruby -rshellwords -e '
       File.foreach(ENV.fetch("ENV_LOCAL_FILE")) do |line|
@@ -31,5 +31,6 @@ if [[ -r config/env.local ]]; then
     '
   )"
 elif [[ -r config/env.1p ]] && grep -qE '^[A-Z][A-Z0-9_]*=' config/env.1p 2>/dev/null; then
+  # Resolve op:// template when env.local is not mounted.
   direnv_load op run --cache --env-file=config/env.1p -- direnv dump
 fi

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -66,12 +66,9 @@ development.  See the `.envrc` file for detail.
 `config/env.1p` in git is the **template**: each variable points at a vault
 item with an `op://` [secret
 reference](https://developer.1password.com/docs/cli/secret-reference), not a
-plaintext value.  `.envrc` uses **`config/env.local`** when that file is
-readable (1Password Environment mount with resolved literals).  An empty
-mount (comments only) means **no secrets** for this repo — `.envrc` does not
-fall back to `config/env.1p`.  When `env.local` is absent and `config/env.1p`
-has variable lines, `.envrc` uses `op run --env-file=config/env.1p` to resolve
-references at load time.
+plaintext value.  Load order and fallbacks are in **`.envrc`**.  Mount
+**resolved** values at **`config/env.local`** (below); use **`config/env.1p`**
+in git when adding or syncing `op://` keys.
 
 For local development, you can also store **resolved** values in a
 [1Password Environment](https://developer.1password.com/docs/environments/) and mount
@@ -102,8 +99,8 @@ refresh the Environment with `op inject` and the 1Password app.
 
 | Path | Role |
 |------|------|
-| `config/env.1p` | Git-tracked template (`op://` references); fallback for `.envrc` / `make config/env` |
-| `config/env.local` | 1Password Environment mount (resolved literals); preferred when present |
+| `config/env.1p` | Git-tracked template (`op://` references); `make config/env` |
+| `config/env.local` | 1Password Environment mount (resolved literals); see `.envrc` |
 
 Do not commit `config/env.local`.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -66,10 +66,12 @@ development.  See the `.envrc` file for detail.
 `config/env.1p` in git is the **template**: each variable points at a vault
 item with an `op://` [secret
 reference](https://developer.1password.com/docs/cli/secret-reference), not a
-plaintext value.  `.envrc` and `make config/env` prefer **`config/env.local`**
-when that file is readable (1Password Environment mount with resolved
-literals); otherwise they use `op run --env-file=config/env.1p` (always in
-git) to resolve references at load time.
+plaintext value.  `.envrc` uses **`config/env.local`** when that file is
+readable (1Password Environment mount with resolved literals).  An empty
+mount (comments only) means **no secrets** for this repo — `.envrc` does not
+fall back to `config/env.1p`.  When `env.local` is absent and `config/env.1p`
+has variable lines, `.envrc` uses `op run --env-file=config/env.1p` to resolve
+references at load time.
 
 For local development, you can also store **resolved** values in a
 [1Password Environment](https://developer.1password.com/docs/environments/) and mount

--- a/{{cookiecutter.project_slug}}/.envrc
+++ b/{{cookiecutter.project_slug}}/.envrc
@@ -1,6 +1,7 @@
 # shellcheck shell=bash
 #
-# Local dev: loads secrets from 1Password via config/env.1p.
+# Local dev: secrets from config/env.local (1Password Environment mount) or,
+# when env.local is absent, op run on config/env.1p only if that file has keys.
 # Cursor / other agents: this is NOT permission to run `op` or `direnv_load` here.
 # Ask the user explicitly before any 1Password CLI use in chat.
 
@@ -29,6 +30,6 @@ if [[ -r config/env.local ]]; then
       end
     '
   )"
-else
+elif [[ -r config/env.1p ]] && grep -qE '^[A-Z][A-Z0-9_]*=' config/env.1p 2>/dev/null; then
   direnv_load op run --cache --env-file=config/env.1p -- direnv dump
 fi

--- a/{{cookiecutter.project_slug}}/.envrc
+++ b/{{cookiecutter.project_slug}}/.envrc
@@ -1,7 +1,5 @@
 # shellcheck shell=bash
 #
-# Local dev: secrets from config/env.local (1Password Environment mount) or,
-# when env.local is absent, op run on config/env.1p only if that file has keys.
 # Cursor / other agents: this is NOT permission to run `op` or `direnv_load` here.
 # Ask the user explicitly before any 1Password CLI use in chat.
 
@@ -11,10 +9,12 @@ watch_file config/env.1p
 watch_file config/env.local
 
 if [[ -r config/env.local ]]; then
+  # Load from mounted Environment file (empty mount => no secrets).
   if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
     echo "config/env.local must contain resolved values, not op:// references." >&2
     exit 1
   fi
+  # Parse KEY=value lines into exports (quoted values unwrapped).
   eval "$(
     ENV_LOCAL_FILE=config/env.local ruby -rshellwords -e '
       File.foreach(ENV.fetch("ENV_LOCAL_FILE")) do |line|
@@ -31,5 +31,6 @@ if [[ -r config/env.local ]]; then
     '
   )"
 elif [[ -r config/env.1p ]] && grep -qE '^[A-Z][A-Z0-9_]*=' config/env.1p 2>/dev/null; then
+  # Resolve op:// template when env.local is not mounted.
   direnv_load op run --cache --env-file=config/env.1p -- direnv dump
 fi

--- a/{{cookiecutter.project_slug}}/DEVELOPMENT.md
+++ b/{{cookiecutter.project_slug}}/DEVELOPMENT.md
@@ -60,10 +60,12 @@ development.  See the `.envrc` file for detail.
 `config/env.1p` in git is the **template**: each variable points at a vault
 item with an `op://` [secret
 reference](https://developer.1password.com/docs/cli/secret-reference), not a
-plaintext value.  `.envrc` and `make config/env` prefer **`config/env.local`**
-when that file is readable (1Password Environment mount with resolved
-literals); otherwise they use `op run --env-file=config/env.1p` (always in
-git) to resolve references at load time.
+plaintext value.  `.envrc` uses **`config/env.local`** when that file is
+readable (1Password Environment mount with resolved literals).  An empty
+mount (comments only) means **no secrets** for this repo — `.envrc` does not
+fall back to `config/env.1p`.  When `env.local` is absent and `config/env.1p`
+has variable lines, `.envrc` uses `op run --env-file=config/env.1p` to resolve
+references at load time.
 
 For local development, you can also store **resolved** values in a
 [1Password Environment](https://developer.1password.com/docs/environments/) and mount

--- a/{{cookiecutter.project_slug}}/DEVELOPMENT.md
+++ b/{{cookiecutter.project_slug}}/DEVELOPMENT.md
@@ -60,12 +60,9 @@ development.  See the `.envrc` file for detail.
 `config/env.1p` in git is the **template**: each variable points at a vault
 item with an `op://` [secret
 reference](https://developer.1password.com/docs/cli/secret-reference), not a
-plaintext value.  `.envrc` uses **`config/env.local`** when that file is
-readable (1Password Environment mount with resolved literals).  An empty
-mount (comments only) means **no secrets** for this repo — `.envrc` does not
-fall back to `config/env.1p`.  When `env.local` is absent and `config/env.1p`
-has variable lines, `.envrc` uses `op run --env-file=config/env.1p` to resolve
-references at load time.
+plaintext value.  Load order and fallbacks are in **`.envrc`**.  Mount
+**resolved** values at **`config/env.local`** (below); use **`config/env.1p`**
+in git when adding or syncing `op://` keys.
 
 For local development, you can also store **resolved** values in a
 [1Password Environment](https://developer.1password.com/docs/environments/) and mount
@@ -96,8 +93,8 @@ refresh the Environment with `op inject` and the 1Password app.
 
 | Path | Role |
 |------|------|
-| `config/env.1p` | Git-tracked template (`op://` references); fallback for `.envrc` / `make config/env` |
-| `config/env.local` | 1Password Environment mount (resolved literals); preferred when present |
+| `config/env.1p` | Git-tracked template (`op://` references); `make config/env` |
+| `config/env.local` | 1Password Environment mount (resolved literals); see `.envrc` |
 
 Do not commit `config/env.local`.
 

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.envrc
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.envrc
@@ -1,6 +1,7 @@
 # shellcheck shell=bash
 #
-# Local dev: loads secrets from 1Password via config/env.1p.
+# Local dev: secrets from config/env.local (1Password Environment mount) or,
+# when env.local is absent, op run on config/env.1p only if that file has keys.
 # Cursor / other agents: this is NOT permission to run `op` or `direnv_load` here.
 # Ask the user explicitly before any 1Password CLI use in chat.
 
@@ -29,6 +30,6 @@ if [[ -r config/env.local ]]; then
       end
     '
   )"
-else
+elif [[ -r config/env.1p ]] && grep -qE '^[A-Z][A-Z0-9_]*=' config/env.1p 2>/dev/null; then
   direnv_load op run --cache --env-file=config/env.1p -- direnv dump
 fi

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.envrc
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.envrc
@@ -1,7 +1,5 @@
 # shellcheck shell=bash
 #
-# Local dev: secrets from config/env.local (1Password Environment mount) or,
-# when env.local is absent, op run on config/env.1p only if that file has keys.
 # Cursor / other agents: this is NOT permission to run `op` or `direnv_load` here.
 # Ask the user explicitly before any 1Password CLI use in chat.
 
@@ -11,10 +9,12 @@ watch_file config/env.1p
 watch_file config/env.local
 
 if [[ -r config/env.local ]]; then
+  # Load from mounted Environment file (empty mount => no secrets).
   if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
     echo "config/env.local must contain resolved values, not op:// references." >&2
     exit 1
   fi
+  # Parse KEY=value lines into exports (quoted values unwrapped).
   eval "$(
     ENV_LOCAL_FILE=config/env.local ruby -rshellwords -e '
       File.foreach(ENV.fetch("ENV_LOCAL_FILE")) do |line|
@@ -31,5 +31,6 @@ if [[ -r config/env.local ]]; then
     '
   )"
 elif [[ -r config/env.1p ]] && grep -qE '^[A-Z][A-Z0-9_]*=' config/env.1p 2>/dev/null; then
+  # Resolve op:// template when env.local is not mounted.
   direnv_load op run --cache --env-file=config/env.1p -- direnv dump
 fi

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/DEVELOPMENT.md
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/DEVELOPMENT.md
@@ -60,12 +60,9 @@ development.  See the `.envrc` file for detail.
 `config/env.1p` in git is the **template**: each variable points at a vault
 item with an `op://` [secret
 reference](https://developer.1password.com/docs/cli/secret-reference), not a
-plaintext value.  `.envrc` uses **`config/env.local`** when that file is
-readable (1Password Environment mount with resolved literals).  An empty
-mount (comments only) means **no secrets** for this repo — `.envrc` does not
-fall back to `config/env.1p`.  When `env.local` is absent and `config/env.1p`
-has variable lines, `.envrc` uses `op run --env-file=config/env.1p` to resolve
-references at load time.
+plaintext value.  Load order and fallbacks are in **`.envrc`**.  Mount
+**resolved** values at **`config/env.local`** (below); use **`config/env.1p`**
+in git when adding or syncing `op://` keys.
 
 For local development, you can also store **resolved** values in a
 [1Password Environment](https://developer.1password.com/docs/environments/) and mount

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/DEVELOPMENT.md
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/DEVELOPMENT.md
@@ -60,10 +60,12 @@ development.  See the `.envrc` file for detail.
 `config/env.1p` in git is the **template**: each variable points at a vault
 item with an `op://` [secret
 reference](https://developer.1password.com/docs/cli/secret-reference), not a
-plaintext value.  `.envrc` and `make config/env` prefer **`config/env.local`**
-when that file is readable (1Password Environment mount with resolved
-literals); otherwise they use `op run --env-file=config/env.1p` (always in
-git) to resolve references at load time.
+plaintext value.  `.envrc` uses **`config/env.local`** when that file is
+readable (1Password Environment mount with resolved literals).  An empty
+mount (comments only) means **no secrets** for this repo — `.envrc` does not
+fall back to `config/env.1p`.  When `env.local` is absent and `config/env.1p`
+has variable lines, `.envrc` uses `op run --env-file=config/env.1p` to resolve
+references at load time.
 
 For local development, you can also store **resolved** values in a
 [1Password Environment](https://developer.1password.com/docs/environments/) and mount


### PR DESCRIPTION
## Summary

- `.envrc` at all three template tiers: use `config/env.local` when readable; `op run` on `config/env.1p` only when `env.local` is absent and the template has keys (no spurious `op run` on empty files).
- Load-order behavior documented inline in `.envrc` (short what-not-how comments), not in long `DEVELOPMENT.md` prose.
- `DEVELOPMENT.md` keeps user-action steps (mount, `op inject`, prerequisites).

## Test plan

- [ ] `direnv reload` with empty mounted `config/env.local` ��� no `op run`
- [ ] `direnv reload` in worktree without `env.local` and empty `env.1p` ��� no `op run`
- [ ] Repo with non-empty `config/env.1p` and no `env.local` still resolves via `op run`
- [ ] CI green