### PR TITLE
Always run post-checkout fix.sh under direnv exec

### DIFF
--- a/bin/git-post-checkout-fix
+++ b/bin/git-post-checkout-fix
@@ -14,8 +14,4 @@ if [ "${branch_checkout}" != '1' ] || [ "${prev_head}" != "${NULL_REF}" ]; then
 fi
 
 # fix.sh calls bin/* helpers; .envrc (via direnv) adds bin/ to PATH.
-if [ -f .envrc ] && command -v direnv >/dev/null 2>&1; then
-  exec direnv exec . ./fix.sh
-fi
-
-exec ./fix.sh
+exec direnv exec . ./fix.sh

--- a/{{cookiecutter.project_slug}}/bin/git-post-checkout-fix
+++ b/{{cookiecutter.project_slug}}/bin/git-post-checkout-fix
@@ -14,8 +14,4 @@ if [ "${branch_checkout}" != '1' ] || [ "${prev_head}" != "${NULL_REF}" ]; then
 fi
 
 # fix.sh calls bin/* helpers; .envrc (via direnv) adds bin/ to PATH.
-if [ -f .envrc ] && command -v direnv >/dev/null 2>&1; then
-  exec direnv exec . ./fix.sh
-fi
-
-exec ./fix.sh
+exec direnv exec . ./fix.sh

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/bin/git-post-checkout-fix
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/bin/git-post-checkout-fix
@@ -14,8 +14,4 @@ if [ "${branch_checkout}" != '1' ] || [ "${prev_head}" != "${NULL_REF}" ]; then
 fi
 
 # fix.sh calls bin/* helpers; .envrc (via direnv) adds bin/ to PATH.
-if [ -f .envrc ] && command -v direnv >/dev/null 2>&1; then
-  exec direnv exec . ./fix.sh
-fi
-
-exec ./fix.sh
+exec direnv exec . ./fix.sh


### PR DESCRIPTION
## Summary

- Remove the conditional fallback in `bin/git-post-checkout-fix` so clone/worktree bootstrap always runs `direnv exec . ./fix.sh`.
- Applied at all three template tiers (meta repo, inner template, nested inner template).

## Test plan

- [ ] CI green on this PR
- [ ] Fresh clone with `core.hooksPath=.githooks` runs bootstrap via direnv on branch checkout


Made with [Cursor](https://cursor.com)