### PR TITLE
Stop watching env files in direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -6,9 +6,6 @@
 
 PATH_add bin
 
-watch_file config/env.1p
-watch_file config/env.local
-
 if [[ -r config/env.local ]]; then
   if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
     echo "config/env.local must contain resolved values, not op:// references." >&2

--- a/{{cookiecutter.project_slug}}/.envrc
+++ b/{{cookiecutter.project_slug}}/.envrc
@@ -6,9 +6,6 @@
 
 PATH_add bin
 
-watch_file config/env.1p
-watch_file config/env.local
-
 if [[ -r config/env.local ]]; then
   if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
     echo "config/env.local must contain resolved values, not op:// references." >&2

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.envrc
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.envrc
@@ -6,9 +6,6 @@
 
 PATH_add bin
 
-watch_file config/env.1p
-watch_file config/env.local
-
 if [[ -r config/env.local ]]; then
   if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
     echo "config/env.local must contain resolved values, not op:// references." >&2


### PR DESCRIPTION
## Summary
- Remove `watch_file` for `config/env.1p` and `config/env.local` from `.envrc` at all template tiers (root, meta-template, and nested project slug).
- Avoids spurious direnv reloads when `env.local` is a bind mount; these files change rarely enough that watching is unnecessary.

Mirrors [apiology/cookiecutter-ruby#360](https://github.com/apiology/cookiecutter-ruby/pull/360).

## Test plan
- [ ] `direnv allow` and confirm env still loads from `config/env.local` or `op run` fallback
- [ ] CI passes

Made with [Cursor](https://cursor.com)