### PR TITLE
Add circleci-env-in-fix-sh rule (meta cascade)

### DIFF
--- a/.cursor/rules/circleci-env-in-fix-sh.mdc
+++ b/.cursor/rules/circleci-env-in-fix-sh.mdc
@@ -1,0 +1,40 @@
+---
+description: >-
+  Treat CIRCLECI (or CI) env branching in fix.sh and bootstrap scripts as a smell —
+  fix belongs in CircleCI config, Makefile targets, or hooks, not shell CI detection
+globs:
+  - "fix.sh"
+  - "bin/**"
+  - ".githooks/**"
+alwaysApply: false
+---
+
+# CIRCLECI env checks in fix.sh (smell)
+
+## Rule
+
+Do **not** add or extend `if [ -n "${CIRCLECI:-}" ]` (or similar) in `fix.sh`, `bin/*`, or git hooks to change install behavior, skip steps, or paper over CI-only failures.
+
+That pattern usually means:
+
+- The **wrong layer** is owning the behavior (bootstrap script vs CI job vs Makefile).
+- The **root cause** in CircleCI (cache, image, checkout, env) was not fixed.
+- Local and CI paths **diverge**, so regressions hide until push.
+
+## Do instead
+
+| Need | Put it here |
+|------|-------------|
+| CI-only setup or retries | `.circleci/config.yml` job `steps` |
+| Optional slow work | Makefile target; CI calls that target explicitly |
+| Post-checkout bootstrap | `fix.sh` / `bin/git-post-checkout-fix` for **all** environments equally |
+| Document a one-off CI quirk | Comment linking the **CircleCI job URL** plus the real fix; remove when CI is corrected |
+
+## Allowed exceptions
+
+- Reading `CIRCLECI` only to **print** diagnostics (no behavior change).
+- Upstream boilerplate you are **removing** in the same PR as part of a CI fix.
+
+## Agents
+
+When reviewing bootstrap changes, prefer deleting CI branches and fixing CircleCI or Makefile. Use `circleci-logs-before-local-ci.mdc` when CI failed before editing `fix.sh`.

--- a/.cursor/rules/template-hierarchy.mdc
+++ b/.cursor/rules/template-hierarchy.mdc
@@ -22,6 +22,7 @@ This repo is the **meta** cookiecutter (`cookiecutter-cookiecutter`). It bakes *
 | Kind of change | Meta root | `{{cookiecutter.project_slug}}/` | Nested project dir |
 |----------------|-----------|-----------------------------------|--------------------|
 | `overcommit-signing.mdc` | Yes | Yes | Yes |
+| `circleci-env-in-fix-sh.mdc` | No | Yes | Yes |
 | `template-hierarchy.mdc` | Yes (this file) | Yes (tier-specific) | No |
 | `fix.sh`, `bin/git-*` hooks, `.githooks/post-checkout`, shared `.overcommit.yml` bootstrap | Yes | Yes | Yes |
 | Boilerplate sync skills/docs | No — in baked child path | Yes | No |

--- a/.cursor/rules/template-hierarchy.mdc
+++ b/.cursor/rules/template-hierarchy.mdc
@@ -22,7 +22,7 @@ This repo is the **meta** cookiecutter (`cookiecutter-cookiecutter`). It bakes *
 | Kind of change | Meta root | `{{cookiecutter.project_slug}}/` | Nested project dir |
 |----------------|-----------|-----------------------------------|--------------------|
 | `overcommit-signing.mdc` | Yes | Yes | Yes |
-| `circleci-env-in-fix-sh.mdc` | No | Yes | Yes |
+| `circleci-env-in-fix-sh.mdc` | Yes | Yes | Yes |
 | `circleci-logs-before-local-ci.mdc` | Yes | Yes | Yes |
 | `pr-review-inline-comments.mdc` | Yes | Yes | Yes |
 | `template-hierarchy.mdc` | Yes (this file) | Yes (tier-specific) | No |

--- a/{{cookiecutter.project_slug}}/.cursor/rules/circleci-env-in-fix-sh.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/circleci-env-in-fix-sh.mdc
@@ -1,0 +1,40 @@
+---
+description: >-
+  Treat CIRCLECI (or CI) env branching in fix.sh and bootstrap scripts as a smell —
+  fix belongs in CircleCI config, Makefile targets, or hooks, not shell CI detection
+globs:
+  - "fix.sh"
+  - "bin/**"
+  - ".githooks/**"
+alwaysApply: false
+---
+
+# CIRCLECI env checks in fix.sh (smell)
+
+## Rule
+
+Do **not** add or extend `if [ -n "${CIRCLECI:-}" ]` (or similar) in `fix.sh`, `bin/*`, or git hooks to change install behavior, skip steps, or paper over CI-only failures.
+
+That pattern usually means:
+
+- The **wrong layer** is owning the behavior (bootstrap script vs CI job vs Makefile).
+- The **root cause** in CircleCI (cache, image, checkout, env) was not fixed.
+- Local and CI paths **diverge**, so regressions hide until push.
+
+## Do instead
+
+| Need | Put it here |
+|------|-------------|
+| CI-only setup or retries | `.circleci/config.yml` job `steps` |
+| Optional slow work | Makefile target; CI calls that target explicitly |
+| Post-checkout bootstrap | `fix.sh` / `bin/git-post-checkout-fix` for **all** environments equally |
+| Document a one-off CI quirk | Comment linking the **CircleCI job URL** plus the real fix; remove when CI is corrected |
+
+## Allowed exceptions
+
+- Reading `CIRCLECI` only to **print** diagnostics (no behavior change).
+- Upstream boilerplate you are **removing** in the same PR as part of a CI fix.
+
+## Agents
+
+When reviewing bootstrap changes, prefer deleting CI branches and fixing CircleCI or Makefile. Use `circleci-logs-before-local-ci.mdc` when CI failed before editing `fix.sh`.

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.cursor/rules/circleci-env-in-fix-sh.mdc
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.cursor/rules/circleci-env-in-fix-sh.mdc
@@ -1,0 +1,40 @@
+---
+description: >-
+  Treat CIRCLECI (or CI) env branching in fix.sh and bootstrap scripts as a smell —
+  fix belongs in CircleCI config, Makefile targets, or hooks, not shell CI detection
+globs:
+  - "fix.sh"
+  - "bin/**"
+  - ".githooks/**"
+alwaysApply: false
+---
+
+# CIRCLECI env checks in fix.sh (smell)
+
+## Rule
+
+Do **not** add or extend `if [ -n "${CIRCLECI:-}" ]` (or similar) in `fix.sh`, `bin/*`, or git hooks to change install behavior, skip steps, or paper over CI-only failures.
+
+That pattern usually means:
+
+- The **wrong layer** is owning the behavior (bootstrap script vs CI job vs Makefile).
+- The **root cause** in CircleCI (cache, image, checkout, env) was not fixed.
+- Local and CI paths **diverge**, so regressions hide until push.
+
+## Do instead
+
+| Need | Put it here |
+|------|-------------|
+| CI-only setup or retries | `.circleci/config.yml` job `steps` |
+| Optional slow work | Makefile target; CI calls that target explicitly |
+| Post-checkout bootstrap | `fix.sh` / `bin/git-post-checkout-fix` for **all** environments equally |
+| Document a one-off CI quirk | Comment linking the **CircleCI job URL** plus the real fix; remove when CI is corrected |
+
+## Allowed exceptions
+
+- Reading `CIRCLECI` only to **print** diagnostics (no behavior change).
+- Upstream boilerplate you are **removing** in the same PR as part of a CI fix.
+
+## Agents
+
+When reviewing bootstrap changes, prefer deleting CI branches and fixing CircleCI or Makefile. Use `circleci-logs-before-local-ci.mdc` when CI failed before editing `fix.sh`.


### PR DESCRIPTION
## Summary
- Relocates [cookiecutter-ruby#365](https://github.com/apiology/cookiecutter-ruby/pull/365) to the meta cookiecutter.
- Adds `circleci-env-in-fix-sh.mdc` at language and nested tiers (not meta root).
- Updates `template-hierarchy.mdc` placement table.

## Test plan
- [ ] CI green