### PR TITLE
Add no_output_timeout to CircleCI fix.sh bootstrap step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ commands:
             - pyenv-
       - run:
           name: Initialize packages
+          no_output_timeout: 30m
           command: |
             # measuring slows down the script - only enable when you
             # want to debug where this is spending time

--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -59,6 +59,7 @@ commands:
             - pyenv-
       - run:
           name: Initialize packages
+          no_output_timeout: 30m
           command: |
             # measuring slows down the script - only enable when you
             # want to debug where this is spending time

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.circleci/config.yml
@@ -59,6 +59,7 @@ commands:
             - pyenv-
       - run:
           name: Initialize packages
+          no_output_timeout: 30m
           command: |
             # measuring slows down the script - only enable when you
             # want to debug where this is spending time


### PR DESCRIPTION
## Summary
- Add `no_output_timeout: 30m` to the CircleCI **Initialize packages** step at meta, language, and nested project tiers.
- Agnostic port from reference repo `origin/main` @ `3f97e29` (checkoff boilerplate sync); Ruby-only CI and bootstrap changes were intentionally excluded.

## Test plan
- [x] `circleci config validate .circleci/config.yml`
- [ ] CI build completes without timing out on long `fix.sh` runs


Made with [Cursor](https://cursor.com)