### PR TITLE
Restore PostCheckout BundleInstall and vendor/.keep ruby dep

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -86,6 +86,10 @@ PreCommit:
     problem_on_unmodified_line: warn
     quiet: false
 
+PostCheckout:
+  BundleInstall:
+    enabled: true
+
 PostCommit:
   BundleInstall:
     enabled: true

--- a/{{cookiecutter.project_slug}}/.overcommit.yml
+++ b/{{cookiecutter.project_slug}}/.overcommit.yml
@@ -86,6 +86,10 @@ PreCommit:
     problem_on_unmodified_line: warn
     quiet: false
 
+PostCheckout:
+  BundleInstall:
+    enabled: true
+
 PostCommit:
   BundleInstall:
     enabled: true

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.overcommit.yml
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.overcommit.yml
@@ -73,6 +73,10 @@ PreCommit:
     problem_on_unmodified_line: warn
     quiet: false
 
+PostCheckout:
+  BundleInstall:
+    enabled: true
+
 PostCommit:
   BundleInstall:
     enabled: true

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/Makefile
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/Makefile
@@ -81,7 +81,7 @@ gem_dependencies: .bundle/config
 Gemfile.lock.installed: Gemfile vendor/.keep
 	touch Gemfile.lock.installed
 
-vendor/.keep: Gemfile.lock
+vendor/.keep: Gemfile.lock .ruby-version
 	make gem_dependencies
 	bundle install
 	touch vendor/.keep


### PR DESCRIPTION
## Summary

Restore `PostCheckout` / `BundleInstall` in template `.overcommit.yml` files (dropped during meta boilerplate sync) and add `.ruby-version` back to the nested `vendor/.keep` Makefile prerequisite.

Follow-up from cookiecutter-chrome-extension#262 review.

## Test plan

- [ ] Merge and propagate via downstream template updates


Made with [Cursor](https://cursor.com)