### PR TITLE
Use CircleCI Docker gen2 resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
               exit 1
             fi
     # This seemed to shave 5ish% of the build time off when added
-    resource_class: large
+    resource_class: large.gen2
 
 workflows:
   version: 2

--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
               exit 1
             fi
     # This seemed to shave 5ish% of the build time off when added
-    resource_class: large
+    resource_class: large.gen2
 
 workflows:
   version: 2

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.circleci/config.yml
@@ -150,7 +150,7 @@ jobs:
 
             make citest cicoverage
     # This seemed to shave 5ish% of the build time off when added
-    resource_class: large
+    resource_class: large.gen2
 
 workflows:
   version: 2


### PR DESCRIPTION
## Summary
- Switch the `build` job from gen1 `large` to `large.gen2` in all three CircleCI config tiers (meta, language, project).
- Keeps the same 4 vCPU / 8 GB sizing while using CircleCI’s faster gen2 Docker infrastructure.

## Test plan
- [ ] CircleCI `build` workflow completes on this branch
- [ ] No resource-class or plan errors from CircleCI