### PR TITLE
Treat worktree env.local symlinks as mounted in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,7 +5,9 @@
 
 PATH_add bin
 
-if [[ -r config/env.local ]]; then
+# -L: worktree symlink to mounted env.local (FIFO; -r is false without a writer).
+# -r: regular file or FIFO with an active reader/writer.
+if [[ -L config/env.local || -r config/env.local ]]; then
   # Load from mounted Environment file (empty mount => no secrets).
   if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
     echo "config/env.local must contain resolved values, not op:// references." >&2

--- a/{{cookiecutter.project_slug}}/.envrc
+++ b/{{cookiecutter.project_slug}}/.envrc
@@ -5,7 +5,9 @@
 
 PATH_add bin
 
-if [[ -r config/env.local ]]; then
+# -L: worktree symlink to mounted env.local (FIFO; -r is false without a writer).
+# -r: regular file or FIFO with an active reader/writer.
+if [[ -L config/env.local || -r config/env.local ]]; then
   # Load from mounted Environment file (empty mount => no secrets).
   if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
     echo "config/env.local must contain resolved values, not op:// references." >&2

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.envrc
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.envrc
@@ -5,7 +5,9 @@
 
 PATH_add bin
 
-if [[ -r config/env.local ]]; then
+# -L: worktree symlink to mounted env.local (FIFO; -r is false without a writer).
+# -r: regular file or FIFO with an active reader/writer.
+if [[ -L config/env.local || -r config/env.local ]]; then
   # Load from mounted Environment file (empty mount => no secrets).
   if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
     echo "config/env.local must contain resolved values, not op:// references." >&2


### PR DESCRIPTION
## Summary
- Check `-L config/env.local` in addition to `-r` at all three meta template tiers (repo root, `{{cookiecutter.project_slug}}/`, nested project path).
- Cursor worktrees symlink `config/env.local`; `-r` alone is false for FIFO symlinks without a writer.

## Test plan
- [ ] Cursor worktree with symlinked `config/env.local` loads via direnv without `op run`
- [ ] Primary checkout with readable `config/env.local` unchanged
- [ ] After merge, fan out via `update_from_cookiecutter` to language templates

## Note
Supersedes https://github.com/apiology/cookiecutter-gem/pull/175 (same fix belongs at meta first).

Made with [Cursor](https://cursor.com)