### PR TITLE
Watch env config files in .envrc across all template tiers

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,6 +5,9 @@
 
 PATH_add bin
 
+watch_file config/env.1p
+watch_file config/env.local
+
 # -L: worktree symlink to mounted env.local (FIFO; -r is false without a writer).
 # -r: regular file or FIFO with an active reader/writer.
 if [[ -L config/env.local || -r config/env.local ]]; then

--- a/{{cookiecutter.project_slug}}/.envrc
+++ b/{{cookiecutter.project_slug}}/.envrc
@@ -5,6 +5,9 @@
 
 PATH_add bin
 
+watch_file config/env.1p
+watch_file config/env.local
+
 # -L: worktree symlink to mounted env.local (FIFO; -r is false without a writer).
 # -r: regular file or FIFO with an active reader/writer.
 if [[ -L config/env.local || -r config/env.local ]]; then

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.envrc
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.envrc
@@ -5,6 +5,9 @@
 
 PATH_add bin
 
+watch_file config/env.1p
+watch_file config/env.local
+
 # -L: worktree symlink to mounted env.local (FIFO; -r is false without a writer).
 # -r: regular file or FIFO with an active reader/writer.
 if [[ -L config/env.local || -r config/env.local ]]; then


### PR DESCRIPTION
## Summary

- Add `watch_file config/env.1p` and `watch_file config/env.local` to `.envrc` at meta root, `{{cookiecutter.project_slug}}/`, and the nested project path.
- Keeps the worktree symlink guard (`-L config/env.local || -r …`) from #615; unifies with the watch-file pattern already in language-tier baked references.

Reference SHAs: meta `14b9ae4`, baked gem nested `.envrc` at `1cc1efc`.

## Test plan

- [x] `make test` (bake + nested bake)
- [ ] CI green on this PR

## Downstream

After merge: cascade to `cookiecutter-ruby` / `cookiecutter-gem` via update-from-upstream-cascade; baked apps pick up via `make update_from_cookiecutter`.