### PR TITLE
Skip brew install when formula is already present

### DIFF
--- a/bin/install_package
+++ b/bin/install_package
@@ -7,7 +7,12 @@ homebrew_package=${1:?homebrew package}
 apt_package=${2:-${homebrew_package}}
 if [ "$(uname)" == "Darwin" ]
 then
-  HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_UPGRADE=1 brew install "${homebrew_package}"
+  # HOMEBREW_NO_INSTALL_UPGRADE makes `brew install` fail when the formula is
+  # already installed at an older version; skip install when it is present.
+  if ! brew list --formula "${homebrew_package}" >/dev/null 2>&1
+  then
+    HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_UPGRADE=1 brew install "${homebrew_package}"
+  fi
 elif type apt-get >/dev/null 2>&1
 then
   if ! dpkg -s "${apt_package}" >/dev/null

--- a/{{cookiecutter.project_slug}}/bin/install_package
+++ b/{{cookiecutter.project_slug}}/bin/install_package
@@ -7,7 +7,12 @@ homebrew_package=${1:?homebrew package}
 apt_package=${2:-${homebrew_package}}
 if [ "$(uname)" == "Darwin" ]
 then
-  HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_UPGRADE=1 brew install "${homebrew_package}"
+  # HOMEBREW_NO_INSTALL_UPGRADE makes `brew install` fail when the formula is
+  # already installed at an older version; skip install when it is present.
+  if ! brew list --formula "${homebrew_package}" >/dev/null 2>&1
+  then
+    HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_UPGRADE=1 brew install "${homebrew_package}"
+  fi
 elif type apt-get >/dev/null 2>&1
 then
   if ! dpkg -s "${apt_package}" >/dev/null

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/bin/install_package
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/bin/install_package
@@ -7,7 +7,12 @@ homebrew_package=${1:?homebrew package}
 apt_package=${2:-${homebrew_package}}
 if [ "$(uname)" == "Darwin" ]
 then
-  HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_UPGRADE=1 brew install "${homebrew_package}"
+  # HOMEBREW_NO_INSTALL_UPGRADE makes `brew install` fail when the formula is
+  # already installed at an older version; skip install when it is present.
+  if ! brew list --formula "${homebrew_package}" >/dev/null 2>&1
+  then
+    HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_UPGRADE=1 brew install "${homebrew_package}"
+  fi
 elif type apt-get >/dev/null 2>&1
 then
   if ! dpkg -s "${apt_package}" >/dev/null


### PR DESCRIPTION
## Summary
- In `bin/install_package`, skip `brew install` when `brew list --formula` shows the package is already installed.
- Avoids non-zero exit under `bash -eu` when Homebrew prints "already installed" / suggests upgrade (e.g. v8 during `./fix.sh`).
- Applied at repo root and both nested template paths.

## Test plan
- [ ] On macOS with v8 already installed, `./fix.sh` passes the handlebars/v8 install step
- [ ] Fresh machine without the formula still installs via brew

Made with [Cursor](https://cursor.com)