### PR TITLE
Port Overcommit sibling-worktree bootstrap

### DIFF
--- a/.git-hooks/bootstrap_local_overcommit.rb
+++ b/.git-hooks/bootstrap_local_overcommit.rb
@@ -1,0 +1,51 @@
+# typed: true
+# frozen_string_literal: true
+
+# Link machine-local Overcommit config across git worktrees and defer signature
+# verification until `overcommit --sign` has run in this worktree (via fix.sh).
+require 'yaml'
+require 'fileutils'
+
+# @param path [String]
+# @return [Hash, nil]
+def load_local_overcommit_config(path)
+  data = YAML.load_file(path)
+  data.is_a?(Hash) ? data : nil
+rescue StandardError
+  nil
+end
+
+# @param repo_root [String]
+# @return [String, nil]
+def sibling_worktree_local_overcommit(repo_root)
+  String(`git worktree list --porcelain 2>/dev/null`).each_line do |line|
+    next unless line.start_with?('worktree ')
+
+    worktree = line.delete_prefix('worktree ').strip
+    next if worktree == repo_root
+
+    candidate = File.join(worktree, '.local-overcommit.yml')
+    return candidate if File.exist?(candidate)
+  end
+  nil
+end
+
+repo_root = String(`git rev-parse --show-toplevel 2>/dev/null`).strip
+exit if repo_root.empty?
+
+local_file = File.join(repo_root, '.local-overcommit.yml')
+
+unless File.exist?(local_file)
+  source = sibling_worktree_local_overcommit(repo_root)
+  # @sg-ignore FileUtils.ln_sf
+  FileUtils.ln_sf(source, local_file) if source
+end
+
+return unless File.exist?(local_file)
+
+raw_config = load_local_overcommit_config(local_file)
+return unless raw_config&.[]('verify_signatures') == false
+
+signed = String(`git config --local --get overcommit.configuration.verifysignatures 2>/dev/null`).strip
+# @sg-ignore Unresolved call to []= on RBS::Unnamed::ENVClass
+ENV['OVERCOMMIT_NO_VERIFY'] = '1' if signed != '0'

--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ types.installed
 /config/env.local
 
 # Overcommit installs hooks here; only bootstrap post-checkout is tracked
+.local-overcommit.yml
 .githooks/*
 !.githooks/post-checkout
 

--- a/fix.sh
+++ b/fix.sh
@@ -429,6 +429,34 @@ EOF
   chmod +x .githooks/post-checkout
 }
 
+patch_overcommit_hooks() {
+  # Inject bootstrap so Cursor worktrees inherit .local-overcommit.yml before
+  # Overcommit loads config (gitignored file is absent on fresh worktree checkout).
+  # Do NOT patch overcommit-hook: it must match the gem template or Overcommit
+  # self-update will reinstall all hooks and strip these patches.
+  local hook hooks_dir bootstrap_line
+  hooks_dir="$(git config --get core.hooksPath 2>/dev/null || echo .git/hooks)"
+  bootstrap_line="repo_root = String(\`git rev-parse --show-toplevel 2>/dev/null\`).strip; load File.join(repo_root, '.git-hooks', 'bootstrap_local_overcommit.rb') rescue nil if repo_root != '' # OVERCOMMIT_REPO_BOOTSTRAP"
+
+  for hook in "${hooks_dir}"/*
+  do
+    [ -f "$hook" ] || continue
+    [[ "$(basename "$hook")" == "overcommit-hook" ]] && continue
+    grep -q 'OVERCOMMIT_REPO_BOOTSTRAP' "$hook" && continue
+    grep -q 'Entrypoint for Overcommit hook integration' "$hook" || continue
+    ruby - "$hook" "$bootstrap_line" <<'RUBY'
+hook_path = ARGV[0]
+bootstrap_line = ARGV[1]
+contents = File.read(hook_path)
+marker = "if ENV['OVERCOMMIT_DISABLE'].to_i != 0 || ENV['OVERCOMMIT_DISABLED'].to_i != 0\n  exit\nend\n"
+unless contents.include?('OVERCOMMIT_REPO_BOOTSTRAP')
+  raise "bootstrap insertion point not found in #{hook_path}" unless contents.include?(marker)
+  File.write(hook_path, contents.sub(marker, "#{marker}\n#{bootstrap_line}\n"))
+end
+RUBY
+  done
+}
+
 ensure_overcommit() {
   # don't run if we're in the middle of a cookiecutter child project
   # test, or otherwise don't have a Git repo to install hooks into...
@@ -437,6 +465,7 @@ ensure_overcommit() {
     bundle exec overcommit --install
     bundle exec overcommit --sign
     bundle exec overcommit --sign pre-commit
+    patch_overcommit_hooks
     install_bootstrap_post_checkout_hook
   else
     >&2 echo 'Not in a git repo; not installing git hooks'

--- a/{{cookiecutter.project_slug}}/.git-hooks/bootstrap_local_overcommit.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/bootstrap_local_overcommit.rb
@@ -1,0 +1,51 @@
+# typed: true
+# frozen_string_literal: true
+
+# Link machine-local Overcommit config across git worktrees and defer signature
+# verification until `overcommit --sign` has run in this worktree (via fix.sh).
+require 'yaml'
+require 'fileutils'
+
+# @param path [String]
+# @return [Hash, nil]
+def load_local_overcommit_config(path)
+  data = YAML.load_file(path)
+  data.is_a?(Hash) ? data : nil
+rescue StandardError
+  nil
+end
+
+# @param repo_root [String]
+# @return [String, nil]
+def sibling_worktree_local_overcommit(repo_root)
+  String(`git worktree list --porcelain 2>/dev/null`).each_line do |line|
+    next unless line.start_with?('worktree ')
+
+    worktree = line.delete_prefix('worktree ').strip
+    next if worktree == repo_root
+
+    candidate = File.join(worktree, '.local-overcommit.yml')
+    return candidate if File.exist?(candidate)
+  end
+  nil
+end
+
+repo_root = String(`git rev-parse --show-toplevel 2>/dev/null`).strip
+exit if repo_root.empty?
+
+local_file = File.join(repo_root, '.local-overcommit.yml')
+
+unless File.exist?(local_file)
+  source = sibling_worktree_local_overcommit(repo_root)
+  # @sg-ignore FileUtils.ln_sf
+  FileUtils.ln_sf(source, local_file) if source
+end
+
+return unless File.exist?(local_file)
+
+raw_config = load_local_overcommit_config(local_file)
+return unless raw_config&.[]('verify_signatures') == false
+
+signed = String(`git config --local --get overcommit.configuration.verifysignatures 2>/dev/null`).strip
+# @sg-ignore Unresolved call to []= on RBS::Unnamed::ENVClass
+ENV['OVERCOMMIT_NO_VERIFY'] = '1' if signed != '0'

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -121,6 +121,7 @@ types.installed
 /config/env.local
 
 # Overcommit installs hooks here; only bootstrap post-checkout is tracked
+.local-overcommit.yml
 .githooks/*
 !.githooks/post-checkout
 

--- a/{{cookiecutter.project_slug}}/fix.sh
+++ b/{{cookiecutter.project_slug}}/fix.sh
@@ -429,6 +429,34 @@ EOF
   chmod +x .githooks/post-checkout
 }
 
+patch_overcommit_hooks() {
+  # Inject bootstrap so Cursor worktrees inherit .local-overcommit.yml before
+  # Overcommit loads config (gitignored file is absent on fresh worktree checkout).
+  # Do NOT patch overcommit-hook: it must match the gem template or Overcommit
+  # self-update will reinstall all hooks and strip these patches.
+  local hook hooks_dir bootstrap_line
+  hooks_dir="$(git config --get core.hooksPath 2>/dev/null || echo .git/hooks)"
+  bootstrap_line="repo_root = String(\`git rev-parse --show-toplevel 2>/dev/null\`).strip; load File.join(repo_root, '.git-hooks', 'bootstrap_local_overcommit.rb') rescue nil if repo_root != '' # OVERCOMMIT_REPO_BOOTSTRAP"
+
+  for hook in "${hooks_dir}"/*
+  do
+    [ -f "$hook" ] || continue
+    [[ "$(basename "$hook")" == "overcommit-hook" ]] && continue
+    grep -q 'OVERCOMMIT_REPO_BOOTSTRAP' "$hook" && continue
+    grep -q 'Entrypoint for Overcommit hook integration' "$hook" || continue
+    ruby - "$hook" "$bootstrap_line" <<'RUBY'
+hook_path = ARGV[0]
+bootstrap_line = ARGV[1]
+contents = File.read(hook_path)
+marker = "if ENV['OVERCOMMIT_DISABLE'].to_i != 0 || ENV['OVERCOMMIT_DISABLED'].to_i != 0\n  exit\nend\n"
+unless contents.include?('OVERCOMMIT_REPO_BOOTSTRAP')
+  raise "bootstrap insertion point not found in #{hook_path}" unless contents.include?(marker)
+  File.write(hook_path, contents.sub(marker, "#{marker}\n#{bootstrap_line}\n"))
+end
+RUBY
+  done
+}
+
 ensure_overcommit() {
   # don't run if we're in the middle of a cookiecutter child project
   # test, or otherwise don't have a Git repo to install hooks into...
@@ -437,6 +465,7 @@ ensure_overcommit() {
     bundle exec overcommit --install
     bundle exec overcommit --sign
     bundle exec overcommit --sign pre-commit
+    patch_overcommit_hooks
     install_bootstrap_post_checkout_hook
   else
     >&2 echo 'Not in a git repo; not installing git hooks'

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.git-hooks/bootstrap_local_overcommit.rb
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.git-hooks/bootstrap_local_overcommit.rb
@@ -1,0 +1,51 @@
+# typed: true
+# frozen_string_literal: true
+
+# Link machine-local Overcommit config across git worktrees and defer signature
+# verification until `overcommit --sign` has run in this worktree (via fix.sh).
+require 'yaml'
+require 'fileutils'
+
+# @param path [String]
+# @return [Hash, nil]
+def load_local_overcommit_config(path)
+  data = YAML.load_file(path)
+  data.is_a?(Hash) ? data : nil
+rescue StandardError
+  nil
+end
+
+# @param repo_root [String]
+# @return [String, nil]
+def sibling_worktree_local_overcommit(repo_root)
+  String(`git worktree list --porcelain 2>/dev/null`).each_line do |line|
+    next unless line.start_with?('worktree ')
+
+    worktree = line.delete_prefix('worktree ').strip
+    next if worktree == repo_root
+
+    candidate = File.join(worktree, '.local-overcommit.yml')
+    return candidate if File.exist?(candidate)
+  end
+  nil
+end
+
+repo_root = String(`git rev-parse --show-toplevel 2>/dev/null`).strip
+exit if repo_root.empty?
+
+local_file = File.join(repo_root, '.local-overcommit.yml')
+
+unless File.exist?(local_file)
+  source = sibling_worktree_local_overcommit(repo_root)
+  # @sg-ignore FileUtils.ln_sf
+  FileUtils.ln_sf(source, local_file) if source
+end
+
+return unless File.exist?(local_file)
+
+raw_config = load_local_overcommit_config(local_file)
+return unless raw_config&.[]('verify_signatures') == false
+
+signed = String(`git config --local --get overcommit.configuration.verifysignatures 2>/dev/null`).strip
+# @sg-ignore Unresolved call to []= on RBS::Unnamed::ENVClass
+ENV['OVERCOMMIT_NO_VERIFY'] = '1' if signed != '0'

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.gitignore
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/.gitignore
@@ -59,6 +59,7 @@ types.installed
 /config/env.local
 
 # Overcommit installs hooks here; only bootstrap post-checkout is tracked
+.local-overcommit.yml
 .githooks/*
 !.githooks/post-checkout
 

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/fix.sh
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/fix.sh
@@ -429,6 +429,34 @@ EOF
   chmod +x .githooks/post-checkout
 }
 
+patch_overcommit_hooks() {
+  # Inject bootstrap so Cursor worktrees inherit .local-overcommit.yml before
+  # Overcommit loads config (gitignored file is absent on fresh worktree checkout).
+  # Do NOT patch overcommit-hook: it must match the gem template or Overcommit
+  # self-update will reinstall all hooks and strip these patches.
+  local hook hooks_dir bootstrap_line
+  hooks_dir="$(git config --get core.hooksPath 2>/dev/null || echo .git/hooks)"
+  bootstrap_line="repo_root = String(\`git rev-parse --show-toplevel 2>/dev/null\`).strip; load File.join(repo_root, '.git-hooks', 'bootstrap_local_overcommit.rb') rescue nil if repo_root != '' # OVERCOMMIT_REPO_BOOTSTRAP"
+
+  for hook in "${hooks_dir}"/*
+  do
+    [ -f "$hook" ] || continue
+    [[ "$(basename "$hook")" == "overcommit-hook" ]] && continue
+    grep -q 'OVERCOMMIT_REPO_BOOTSTRAP' "$hook" && continue
+    grep -q 'Entrypoint for Overcommit hook integration' "$hook" || continue
+    ruby - "$hook" "$bootstrap_line" <<'RUBY'
+hook_path = ARGV[0]
+bootstrap_line = ARGV[1]
+contents = File.read(hook_path)
+marker = "if ENV['OVERCOMMIT_DISABLE'].to_i != 0 || ENV['OVERCOMMIT_DISABLED'].to_i != 0\n  exit\nend\n"
+unless contents.include?('OVERCOMMIT_REPO_BOOTSTRAP')
+  raise "bootstrap insertion point not found in #{hook_path}" unless contents.include?(marker)
+  File.write(hook_path, contents.sub(marker, "#{marker}\n#{bootstrap_line}\n"))
+end
+RUBY
+  done
+}
+
 ensure_overcommit() {
   # don't run if we're in the middle of a cookiecutter child project
   # test, or otherwise don't have a Git repo to install hooks into...
@@ -437,6 +465,7 @@ ensure_overcommit() {
     bundle exec overcommit --install
     bundle exec overcommit --sign
     bundle exec overcommit --sign pre-commit
+    patch_overcommit_hooks
     install_bootstrap_post_checkout_hook
   else
     >&2 echo 'Not in a git repo; not installing git hooks'


### PR DESCRIPTION
## Summary

Ports the Overcommit sibling-worktree bootstrap from the baked gem reference (checkoff @ fdaf473) into all three template tiers:

- **`.git-hooks/bootstrap_local_overcommit.rb`** — symlinks `.local-overcommit.yml` from a sibling git worktree when missing locally; defers signature verification until `fix.sh` runs `overcommit --sign`.
- **`fix.sh`** — adds `patch_overcommit_hooks()` and calls it from `ensure_overcommit()` so hooks load the bootstrap before Overcommit reads config.
- **`.gitignore`** — ignores `.local-overcommit.yml` (machine-local, not committed).

This belongs at the meta tier per `template-hierarchy.mdc` (shared Overcommit bootstrap alongside `.githooks/post-checkout`).

## Test plan

- [x] `direnv exec . make test` (bake + flake8/mypy/overcommit) in isolated worktree
- [ ] CI green on this PR