### PR TITLE
Install lockfile Bundler version in ensure_bundle

### DIFF
--- a/fix.sh
+++ b/fix.sh
@@ -188,6 +188,12 @@ ensure_bundle() {
       bundler_version=$(bundle --version | cut -d ' ' -f 3)
   fi
   echo "Bundler version: ${bundler_version}"
+  active_bundler_version=$(bundle --version 2>/dev/null | cut -d ' ' -f 3)
+  if [ -n "${bundler_version}" ] && [ "${bundler_version}" != "${active_bundler_version}" ]
+  then
+    gem install "bundler:${bundler_version}"
+    hash -r
+  fi
   bundler_version_major=$(cut -d. -f1 <<< "${bundler_version}")
   bundler_version_minor=$(cut -d. -f2 <<< "${bundler_version}")
   bundler_version_patch=$(cut -d. -f3 <<< "${bundler_version}")

--- a/{{cookiecutter.project_slug}}/fix.sh
+++ b/{{cookiecutter.project_slug}}/fix.sh
@@ -188,6 +188,12 @@ ensure_bundle() {
       bundler_version=$(bundle --version | cut -d ' ' -f 3)
   fi
   echo "Bundler version: ${bundler_version}"
+  active_bundler_version=$(bundle --version 2>/dev/null | cut -d ' ' -f 3)
+  if [ -n "${bundler_version}" ] && [ "${bundler_version}" != "${active_bundler_version}" ]
+  then
+    gem install "bundler:${bundler_version}"
+    hash -r
+  fi
   bundler_version_major=$(cut -d. -f1 <<< "${bundler_version}")
   bundler_version_minor=$(cut -d. -f2 <<< "${bundler_version}")
   bundler_version_patch=$(cut -d. -f3 <<< "${bundler_version}")

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/fix.sh
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/fix.sh
@@ -188,6 +188,12 @@ ensure_bundle() {
       bundler_version=$(bundle --version | cut -d ' ' -f 3)
   fi
   echo "Bundler version: ${bundler_version}"
+  active_bundler_version=$(bundle --version 2>/dev/null | cut -d ' ' -f 3)
+  if [ -n "${bundler_version}" ] && [ "${bundler_version}" != "${active_bundler_version}" ]
+  then
+    gem install "bundler:${bundler_version}"
+    hash -r
+  fi
   bundler_version_major=$(cut -d. -f1 <<< "${bundler_version}")
   bundler_version_minor=$(cut -d. -f2 <<< "${bundler_version}")
   bundler_version_patch=$(cut -d. -f3 <<< "${bundler_version}")


### PR DESCRIPTION
## Summary

Adds a small block to `ensure_bundle()` in all three parallel `fix.sh` paths (root, `{{cookiecutter.project_slug}}/`, deep nested):

When `Gemfile.lock` pins a Bundler version that differs from the active `bundle` on PATH, run `gem install bundler:<lockfile version>` before continuing. This prevents CI `verify-deltas` from rewriting the lockfile when the image ships an older default Bundler (e.g. 2.5.22 vs lockfile 4.0.13).

Ported from [cookiecutter-chrome-extension PR #263](https://github.com/apiology/cookiecutter-chrome-extension/pull/263) commit `859975a`; dropped there per review because it belongs in this repo, not in a language template.

## Risks

- Low: only runs when lockfile Bundler ≠ active Bundler; uses existing `gem install` pattern already in `ensure_bundle`.

## Test plan

- [ ] CI green (`build` + `quality`)
- [ ] Local `./fix.sh` with a lockfile-pinned Bundler newer than system default