### PR TITLE
Add Homebrew to PATH in fix.sh for git hook bootstrap

### DIFF
--- a/fix.sh
+++ b/fix.sh
@@ -22,6 +22,23 @@ debug_timing
 
 set -o pipefail
 
+ensure_homebrew_path() {
+  if [ "$(uname)" != "Darwin" ]
+  then
+    return 0
+  fi
+
+  local prefix
+  for prefix in /opt/homebrew /usr/local
+  do
+    if [ -x "${prefix}/bin/brew" ]
+    then
+      export PATH="${prefix}/bin:${prefix}/sbin:${PATH}"
+      return 0
+    fi
+  done
+}
+
 install_rbenv() {
   if [ "$(uname)" == "Darwin" ]
   then
@@ -45,6 +62,7 @@ EOF
 }
 
 set_rbenv_env_variables() {
+  ensure_homebrew_path
   export PATH="${HOME}/.rbenv/bin:$PATH"
   eval "$(rbenv init -)"
 }
@@ -67,6 +85,8 @@ ensure_ruby_build() {
 }
 
 ensure_rbenv() {
+  ensure_homebrew_path
+
   if ! type rbenv >/dev/null 2>&1 && ! [ -f "${HOME}/.rbenv/bin/rbenv" ]
   then
     install_rbenv

--- a/{{cookiecutter.project_slug}}/fix.sh
+++ b/{{cookiecutter.project_slug}}/fix.sh
@@ -22,6 +22,23 @@ debug_timing
 
 set -o pipefail
 
+ensure_homebrew_path() {
+  if [ "$(uname)" != "Darwin" ]
+  then
+    return 0
+  fi
+
+  local prefix
+  for prefix in /opt/homebrew /usr/local
+  do
+    if [ -x "${prefix}/bin/brew" ]
+    then
+      export PATH="${prefix}/bin:${prefix}/sbin:${PATH}"
+      return 0
+    fi
+  done
+}
+
 install_rbenv() {
   if [ "$(uname)" == "Darwin" ]
   then
@@ -45,6 +62,7 @@ EOF
 }
 
 set_rbenv_env_variables() {
+  ensure_homebrew_path
   export PATH="${HOME}/.rbenv/bin:$PATH"
   eval "$(rbenv init -)"
 }
@@ -67,6 +85,8 @@ ensure_ruby_build() {
 }
 
 ensure_rbenv() {
+  ensure_homebrew_path
+
   if ! type rbenv >/dev/null 2>&1 && ! [ -f "${HOME}/.rbenv/bin/rbenv" ]
   then
     install_rbenv

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/fix.sh
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/fix.sh
@@ -22,6 +22,23 @@ debug_timing
 
 set -o pipefail
 
+ensure_homebrew_path() {
+  if [ "$(uname)" != "Darwin" ]
+  then
+    return 0
+  fi
+
+  local prefix
+  for prefix in /opt/homebrew /usr/local
+  do
+    if [ -x "${prefix}/bin/brew" ]
+    then
+      export PATH="${prefix}/bin:${prefix}/sbin:${PATH}"
+      return 0
+    fi
+  done
+}
+
 install_rbenv() {
   if [ "$(uname)" == "Darwin" ]
   then
@@ -45,6 +62,7 @@ EOF
 }
 
 set_rbenv_env_variables() {
+  ensure_homebrew_path
   export PATH="${HOME}/.rbenv/bin:$PATH"
   eval "$(rbenv init -)"
 }
@@ -67,6 +85,8 @@ ensure_ruby_build() {
 }
 
 ensure_rbenv() {
+  ensure_homebrew_path
+
   if ! type rbenv >/dev/null 2>&1 && ! [ -f "${HOME}/.rbenv/bin/rbenv" ]
   then
     install_rbenv


### PR DESCRIPTION
## Summary

- Add `ensure_homebrew_path()` to all three `fix.sh` tiers so macOS git hooks can find Homebrew-installed `brew` and `rbenv`.
- Call it from `ensure_rbenv()` and `set_rbenv_env_variables()` before any rbenv setup runs.

Fixes Cursor worktree creation failing when the post-checkout hook runs `./fix.sh` with a minimal PATH (no `/opt/homebrew/bin`), which made Homebrew-installed rbenv invisible.

## Test plan

- [x] Reproduced original failure: `env -i PATH="/usr/bin:/bin:/usr/sbin:/sbin" bash --noprofile --norc -c './fix.sh'` on old code fails with `brew`/`rbenv` not found
- [x] Verified fix on main repo: same minimal-PATH run completes Ruby bootstrap without brew/rbenv errors
- [ ] After merge, create a new Cursor worktree and confirm post-checkout bootstrap succeeds