### PR TITLE
Add pyenv shims to PATH in fix.sh for git hook bootstrap

### DIFF
--- a/fix.sh
+++ b/fix.sh
@@ -305,14 +305,17 @@ set_pyenv_env_variables() {
   #
   # https://app.circleci.com/pipelines/github/apiology/cookiecutter-pypackage/15/workflows/10506069-7662-46bd-b915-2992db3f795b/jobs/15
   set +u
+  ensure_homebrew_path
   export PYENV_ROOT="${HOME}/.pyenv"
-  export PATH="${PYENV_ROOT}/bin:$PATH"
+  export PATH="${PYENV_ROOT}/bin:${PYENV_ROOT}/shims:${PATH}"
   eval "$(pyenv init --path)"
   eval "$(pyenv virtualenv-init -)"
   set -u
 }
 
 ensure_pyenv() {
+  ensure_homebrew_path
+
   if ! type pyenv >/dev/null 2>&1 && ! [ -f "${HOME}/.pyenv/bin/pyenv" ]
   then
     install_pyenv
@@ -406,6 +409,8 @@ ensure_pyenv_virtualenvs() {
 }
 
 ensure_pip_and_wheel() {
+  set_pyenv_env_variables
+
   # https://cve.mitre.org/cgi-bin/cvename.cgi?name=2023-5752
   pip_version=$(python -c "import pip; print(pip.__version__)" | cut -d' ' -f2)
   major_pip_version=$(cut -d '.' -f 1 <<< "${pip_version}")

--- a/fix.sh
+++ b/fix.sh
@@ -321,10 +321,7 @@ ensure_pyenv() {
     install_pyenv
   fi
 
-  if ! type pyenv >/dev/null 2>&1
-  then
-    set_pyenv_env_variables
-  fi
+  set_pyenv_env_variables
 }
 
 update_package() {
@@ -409,8 +406,6 @@ ensure_pyenv_virtualenvs() {
 }
 
 ensure_pip_and_wheel() {
-  set_pyenv_env_variables
-
   # https://cve.mitre.org/cgi-bin/cvename.cgi?name=2023-5752
   pip_version=$(python -c "import pip; print(pip.__version__)" | cut -d' ' -f2)
   major_pip_version=$(cut -d '.' -f 1 <<< "${pip_version}")

--- a/{{cookiecutter.project_slug}}/fix.sh
+++ b/{{cookiecutter.project_slug}}/fix.sh
@@ -305,14 +305,17 @@ set_pyenv_env_variables() {
   #
   # https://app.circleci.com/pipelines/github/apiology/cookiecutter-pypackage/15/workflows/10506069-7662-46bd-b915-2992db3f795b/jobs/15
   set +u
+  ensure_homebrew_path
   export PYENV_ROOT="${HOME}/.pyenv"
-  export PATH="${PYENV_ROOT}/bin:$PATH"
+  export PATH="${PYENV_ROOT}/bin:${PYENV_ROOT}/shims:${PATH}"
   eval "$(pyenv init --path)"
   eval "$(pyenv virtualenv-init -)"
   set -u
 }
 
 ensure_pyenv() {
+  ensure_homebrew_path
+
   if ! type pyenv >/dev/null 2>&1 && ! [ -f "${HOME}/.pyenv/bin/pyenv" ]
   then
     install_pyenv
@@ -406,6 +409,8 @@ ensure_pyenv_virtualenvs() {
 }
 
 ensure_pip_and_wheel() {
+  set_pyenv_env_variables
+
   # https://cve.mitre.org/cgi-bin/cvename.cgi?name=2023-5752
   pip_version=$(python -c "import pip; print(pip.__version__)" | cut -d' ' -f2)
   major_pip_version=$(cut -d '.' -f 1 <<< "${pip_version}")

--- a/{{cookiecutter.project_slug}}/fix.sh
+++ b/{{cookiecutter.project_slug}}/fix.sh
@@ -321,10 +321,7 @@ ensure_pyenv() {
     install_pyenv
   fi
 
-  if ! type pyenv >/dev/null 2>&1
-  then
-    set_pyenv_env_variables
-  fi
+  set_pyenv_env_variables
 }
 
 update_package() {
@@ -409,8 +406,6 @@ ensure_pyenv_virtualenvs() {
 }
 
 ensure_pip_and_wheel() {
-  set_pyenv_env_variables
-
   # https://cve.mitre.org/cgi-bin/cvename.cgi?name=2023-5752
   pip_version=$(python -c "import pip; print(pip.__version__)" | cut -d' ' -f2)
   major_pip_version=$(cut -d '.' -f 1 <<< "${pip_version}")

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/fix.sh
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/fix.sh
@@ -305,14 +305,17 @@ set_pyenv_env_variables() {
   #
   # https://app.circleci.com/pipelines/github/apiology/cookiecutter-pypackage/15/workflows/10506069-7662-46bd-b915-2992db3f795b/jobs/15
   set +u
+  ensure_homebrew_path
   export PYENV_ROOT="${HOME}/.pyenv"
-  export PATH="${PYENV_ROOT}/bin:$PATH"
+  export PATH="${PYENV_ROOT}/bin:${PYENV_ROOT}/shims:${PATH}"
   eval "$(pyenv init --path)"
   eval "$(pyenv virtualenv-init -)"
   set -u
 }
 
 ensure_pyenv() {
+  ensure_homebrew_path
+
   if ! type pyenv >/dev/null 2>&1 && ! [ -f "${HOME}/.pyenv/bin/pyenv" ]
   then
     install_pyenv
@@ -406,6 +409,8 @@ ensure_pyenv_virtualenvs() {
 }
 
 ensure_pip_and_wheel() {
+  set_pyenv_env_variables
+
   # https://cve.mitre.org/cgi-bin/cvename.cgi?name=2023-5752
   pip_version=$(python -c "import pip; print(pip.__version__)" | cut -d' ' -f2)
   major_pip_version=$(cut -d '.' -f 1 <<< "${pip_version}")

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/fix.sh
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/fix.sh
@@ -321,10 +321,7 @@ ensure_pyenv() {
     install_pyenv
   fi
 
-  if ! type pyenv >/dev/null 2>&1
-  then
-    set_pyenv_env_variables
-  fi
+  set_pyenv_env_variables
 }
 
 update_package() {
@@ -409,8 +406,6 @@ ensure_pyenv_virtualenvs() {
 }
 
 ensure_pip_and_wheel() {
-  set_pyenv_env_variables
-
   # https://cve.mitre.org/cgi-bin/cvename.cgi?name=2023-5752
   pip_version=$(python -c "import pip; print(pip.__version__)" | cut -d' ' -f2)
   major_pip_version=$(cut -d '.' -f 1 <<< "${pip_version}")


### PR DESCRIPTION
## Summary

- Add Homebrew and pyenv shims to PATH in `set_pyenv_env_variables()` (all three `fix.sh` tiers).
- Always call `set_pyenv_env_variables` from `ensure_pyenv()` — same pattern as `ensure_rbenv()`.

Fixes worktree creation failing after PR #623 with `python: command not found` at line 410 when the post-checkout hook runs `./fix.sh` with a minimal PATH. Homebrew can make `type pyenv` succeed while shims are still missing from PATH; the old conditional skipped setup in that case.

## Test plan

- [x] Minimal-PATH simulation: `env -i PATH="/usr/bin:/bin:/usr/sbin:/sbin" bash --noprofile --norc -c './fix.sh'` completes through overcommit install
- [ ] After merge, request a Cursor worktree — pre-sync hook ff's `main`, post-checkout bootstrap completes
