### PR TITLE
Gate update_from_cookiecutter on fresh template parent SHA

### DIFF
--- a/bin/cookiecutter_project_upgrader.sh
+++ b/bin/cookiecutter_project_upgrader.sh
@@ -10,7 +10,6 @@ cookiecutter_project_upgrader --help >/dev/null
 MAIN_REPO_ROOT="$(dirname "$(git rev-parse --git-common-dir)")"
 GIT_DIR_PATH="$(git rev-parse --git-dir)"
 MAKE_DIR=".make"
-STAMP_FILE="${MAKE_DIR}/template-parent-sha"
 TEMPLATE_BRANCH="${COOKIECUTTER_TEMPLATE_BRANCH:-cookiecutter-template}"
 TEMPLATE_UPGRADE_BRANCH="${COOKIECUTTER_TEMPLATE_UPGRADE_BRANCH:-main}"
 GIT_WORKTREE_SHIM=0
@@ -78,48 +77,6 @@ wipe_template_cache() {
   fi
 }
 
-resolve_template_parent_sha() {
-  local url=$1 branch=$2 cache="" sha=""
-  if git remote get-url cookiecutter-upstream &>/dev/null; then
-    git fetch cookiecutter-upstream "${branch}"
-    git rev-parse "cookiecutter-upstream/${branch}"
-    return 0
-  fi
-  if cache="$(cookiecutter_cache_dir "${url}")" && [ -d "${cache}/.git" ]; then
-    git -C "${cache}" rev-parse "${branch}" 2>/dev/null \
-      || git -C "${cache}" rev-parse "origin/${branch}"
-    return 0
-  fi
-  if [ -n "${url}" ]; then
-    sha="$(git ls-remote "${url}" "refs/heads/${branch}" | awk 'NR==1 { print $1; exit }')"
-    [ -n "${sha}" ] || {
-      echo "error: could not resolve parent SHA for ${url} @ ${branch}" >&2
-      return 1
-    }
-    printf '%s\n' "${sha}"
-    return 0
-  fi
-  echo "error: no template URL or cookiecutter-upstream for parent SHA" >&2
-  return 1
-}
-
-stamp_template_parent_sha() {
-  local parent_sha=$1 wt=""
-  wt="$(mktemp -d)"
-  trap 'git worktree remove --force "${wt}" &>/dev/null; rm -rf "${wt}"' RETURN
-
-  git worktree add --detach "${wt}" "${TEMPLATE_BRANCH}"
-  mkdir -p "${wt}/${MAKE_DIR}"
-  printf '%s\n' "${parent_sha}" > "${wt}/${STAMP_FILE}"
-  if git -C "${wt}" diff --quiet -- "${STAMP_FILE}"; then
-    echo "template-parent-sha already on ${TEMPLATE_BRANCH}"
-    return 0
-  fi
-  git -C "${wt}" add "${STAMP_FILE}"
-  git -C "${wt}" commit -m "Record template parent SHA ${parent_sha:0:12}"
-  git push origin "HEAD:${TEMPLATE_BRANCH}"
-}
-
 hide_for_bake "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
 hide_for_bake "${MAIN_REPO_ROOT}/.rubocop.yml" "${MAKE_DIR}/rubocop-main.yml.bak"
 hide_for_bake "${REPO_CWD}/.rubocop.yml" "${MAKE_DIR}/rubocop-cwd.yml.bak"
@@ -151,10 +108,6 @@ if ! cookiecutter_project_upgrader "${UPGRADER_ARGS[@]}"; then
   fi
   echo "cookiecutter_project_upgrader reported no template diff"
 fi
-
-PARENT_SHA="$(resolve_template_parent_sha "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}")"
-echo "Template parent SHA (${TEMPLATE_UPGRADE_BRANCH}): ${PARENT_SHA}"
-stamp_template_parent_sha "${PARENT_SHA}"
 
 trap - EXIT
 cleanup_prepare

--- a/bin/cookiecutter_project_upgrader.sh
+++ b/bin/cookiecutter_project_upgrader.sh
@@ -10,6 +10,9 @@ cookiecutter_project_upgrader --help >/dev/null
 MAIN_REPO_ROOT="$(dirname "$(git rev-parse --git-common-dir)")"
 GIT_DIR_PATH="$(git rev-parse --git-dir)"
 MAKE_DIR=".make"
+TEMPLATE_BRANCH="${COOKIECUTTER_TEMPLATE_BRANCH:-cookiecutter-template}"
+TEMPLATE_PARENT_SHA_FILE=".make/template-parent-sha"
+TEMPLATE_UPGRADE_BRANCH="${COOKIECUTTER_TEMPLATE_UPGRADE_BRANCH:-main}"
 RBS_HIDDEN=0
 RUBOCOP_MAIN_HIDDEN=0
 RUBOCOP_CWD_HIDDEN=0
@@ -46,10 +49,126 @@ trap cleanup_prepare EXIT
 
 mkdir -p "${MAKE_DIR}"
 
+CONTEXT_FILE="${MAKE_DIR}/cookiecutter_context.json"
 if [ -f docs/cookiecutter_input.json ]; then
   jq 'del(._output_dir, ._repo_dir, ._checkout)' docs/cookiecutter_input.json \
-    > "${MAKE_DIR}/cookiecutter_context.json"
+    > "${CONTEXT_FILE}"
 fi
+
+template_url_from_context() {
+  jq -r '._template // empty' "${CONTEXT_FILE}"
+}
+
+cookiecutter_cache_dir() {
+  local template_url=$1
+  local repo_name=""
+
+  if [[ "${template_url}" =~ github\.com[:/][^/]+/([^/.]+)(\.git)?/?$ ]]; then
+    repo_name="${BASH_REMATCH[1]}"
+  elif [[ "${template_url}" =~ ^git@github\.com:[^/]+/([^/.]+)(\.git)?$ ]]; then
+    repo_name="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+
+  echo "${HOME}/.cookiecutters/${repo_name}"
+}
+
+refresh_template_cache() {
+  local template_url=$1
+  local upgrade_branch=$2
+  local cache_dir=""
+
+  if ! cache_dir="$(cookiecutter_cache_dir "${template_url}")"; then
+    echo "warning: could not derive cookiecutter cache dir from template URL: ${template_url}" >&2
+    return 0
+  fi
+
+  if [ ! -d "${cache_dir}/.git" ]; then
+    echo "cookiecutter cache not present yet at ${cache_dir}; cookiecutter will clone on bake" >&2
+    return 0
+  fi
+
+  echo "Refreshing cookiecutter template cache ${cache_dir} @ ${upgrade_branch}"
+  git -C "${cache_dir}" fetch origin "${upgrade_branch}"
+  git -C "${cache_dir}" checkout "${upgrade_branch}"
+  git -C "${cache_dir}" merge --ff-only "origin/${upgrade_branch}"
+}
+
+resolve_template_parent_sha() {
+  local template_url=$1
+  local upgrade_branch=$2
+
+  if git remote get-url cookiecutter-upstream >/dev/null 2>&1; then
+    git fetch cookiecutter-upstream "${upgrade_branch}"
+    git rev-parse "cookiecutter-upstream/${upgrade_branch}"
+    return 0
+  fi
+
+  local cache_dir=""
+  if cache_dir="$(cookiecutter_cache_dir "${template_url}")" && [ -d "${cache_dir}/.git" ]; then
+    git -C "${cache_dir}" rev-parse "origin/${upgrade_branch}"
+    return 0
+  fi
+
+  git fetch origin "${upgrade_branch}"
+  git rev-parse "origin/${upgrade_branch}"
+}
+
+read_template_parent_stamp() {
+  if git rev-parse --verify "${TEMPLATE_BRANCH}" >/dev/null 2>&1; then
+    git show "${TEMPLATE_BRANCH}:${TEMPLATE_PARENT_SHA_FILE}" 2>/dev/null | tr -d '[:space:]' || true
+  fi
+}
+
+stamp_template_parent_sha() {
+  local parent_sha=$1
+  local stamp_worktree=""
+
+  stamp_worktree="$(mktemp -d "${TMPDIR:-/tmp}/cookiecutter-template-stamp.XXXXXX")"
+  cleanup_stamp_worktree() {
+    git worktree remove --force "${stamp_worktree}" >/dev/null 2>&1 || true
+    rm -rf "${stamp_worktree}"
+  }
+  trap cleanup_stamp_worktree RETURN
+
+  git worktree add --detach "${stamp_worktree}" "${TEMPLATE_BRANCH}"
+  mkdir -p "${stamp_worktree}/.make"
+  printf '%s\n' "${parent_sha}" > "${stamp_worktree}/${TEMPLATE_PARENT_SHA_FILE}"
+  if git -C "${stamp_worktree}" diff --quiet -- "${TEMPLATE_PARENT_SHA_FILE}"; then
+    echo "template-parent-sha already recorded on ${TEMPLATE_BRANCH}"
+    return 0
+  fi
+  git -C "${stamp_worktree}" add "${TEMPLATE_PARENT_SHA_FILE}"
+  git -C "${stamp_worktree}" commit -m "Record template parent SHA ${parent_sha:0:12}"
+  git push origin "HEAD:${TEMPLATE_BRANCH}"
+}
+
+verify_template_branch_freshness() {
+  local parent_sha=$1
+  local tip_before=$2
+  local tip_after=$3
+  local stamp=""
+
+  stamp="$(read_template_parent_stamp)"
+  if [ "${tip_before}" != "${tip_after}" ]; then
+    if [ "${stamp}" != "${parent_sha}" ]; then
+      stamp_template_parent_sha "${parent_sha}"
+    fi
+    echo "Re-baked ${TEMPLATE_BRANCH}: ${tip_before:0:12} -> ${tip_after:0:12} @ parent ${parent_sha:0:12}"
+    return 0
+  fi
+
+  if [ "${stamp}" = "${parent_sha}" ]; then
+    echo "Template branch already matches parent ${parent_sha:0:12}; continuing idempotently"
+    return 0
+  fi
+
+  >&2 echo "error: ${TEMPLATE_BRANCH} tip unchanged (${tip_after:0:12}) but parent is ${parent_sha:0:12}"
+  >&2 echo "       recorded stamp: ${stamp:-<missing>}"
+  >&2 echo "       Refresh failed or bake used stale template cache; fix cache/upstream and retry."
+  exit 1
+}
 
 if [ -f "${MAIN_REPO_ROOT}/rbs_collection.yaml" ]; then
   mv "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
@@ -84,12 +203,37 @@ elif [ -f .git ] && [ ! -L .git ]; then
   exit 1
 fi
 
-export IN_COOKIECUTTER_PROJECT_UPGRADER=1
-if [ -f "${MAKE_DIR}/cookiecutter_context.json" ]; then
-  cookiecutter_project_upgrader -c "${MAKE_DIR}/cookiecutter_context.json" -p true
-else
-  cookiecutter_project_upgrader
+TEMPLATE_URL=""
+if [ -f "${CONTEXT_FILE}" ]; then
+  TEMPLATE_URL="$(template_url_from_context)"
 fi
+if [ -n "${TEMPLATE_URL}" ]; then
+  refresh_template_cache "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}"
+fi
+PARENT_SHA="$(resolve_template_parent_sha "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}")"
+echo "Template parent SHA (${TEMPLATE_UPGRADE_BRANCH}): ${PARENT_SHA}"
+
+if git rev-parse --verify "${TEMPLATE_BRANCH}" >/dev/null 2>&1; then
+  TEMPLATE_TIP_BEFORE="$(git rev-parse "${TEMPLATE_BRANCH}")"
+else
+  TEMPLATE_TIP_BEFORE=""
+fi
+
+export IN_COOKIECUTTER_PROJECT_UPGRADER=1
+UPGRADER_ARGS=(-p true -u "${TEMPLATE_UPGRADE_BRANCH}")
+if [ -f "${CONTEXT_FILE}" ]; then
+  UPGRADER_ARGS=(-c "${CONTEXT_FILE}" "${UPGRADER_ARGS[@]}")
+fi
+if ! cookiecutter_project_upgrader "${UPGRADER_ARGS[@]}"; then
+  if [ -z "${TEMPLATE_TIP_BEFORE}" ] || ! git rev-parse --verify "${TEMPLATE_BRANCH}" >/dev/null 2>&1; then
+    >&2 echo "error: cookiecutter_project_upgrader failed and ${TEMPLATE_BRANCH} is missing"
+    exit 1
+  fi
+  echo "cookiecutter_project_upgrader reported no template diff; checking parent SHA stamp"
+fi
+
+TEMPLATE_TIP_AFTER="$(git rev-parse "${TEMPLATE_BRANCH}")"
+verify_template_branch_freshness "${PARENT_SHA}" "${TEMPLATE_TIP_BEFORE}" "${TEMPLATE_TIP_AFTER}"
 
 trap - EXIT
 cleanup_prepare
@@ -105,7 +249,7 @@ if ! git diff --quiet -- Makefile 2>/dev/null || ! git diff --cached --quiet -- 
   touch "${MAKE_DIR}/cookiecutter_makefile_stashed"
 fi
 
-git push --no-verify origin cookiecutter-template || true
+git push --no-verify origin "${TEMPLATE_BRANCH}"
 
 git fetch "origin" "${DEFAULT_BRANCH}"
 UPDATE_BRANCH="update-from-cookiecutter-$(date +%Y-%m-%d-%H%M)"
@@ -116,7 +260,7 @@ bin/overcommit --sign
 bin/overcommit --sign pre-commit
 bin/overcommit --sign pre-push
 
-git merge cookiecutter-template || true
+git merge "${TEMPLATE_BRANCH}"
 git checkout --ours Gemfile.lock || true
 
 if [ -f "${MAKE_DIR}/cookiecutter_makefile_stashed" ]; then
@@ -131,5 +275,5 @@ bin/overcommit --install || true
 echo
 echo "Please resolve any merge conflicts below and push up a PR with:"
 echo
-echo '   gh pr create --title "Update from cookiecutter" --body "Automated PR to update from cookiecutter boilerplate"'
+echo '   gh pr create --title "Update from upstream" --body "Automated PR to update from upstream boilerplate"'
 echo

--- a/bin/cookiecutter_project_upgrader.sh
+++ b/bin/cookiecutter_project_upgrader.sh
@@ -10,14 +10,30 @@ cookiecutter_project_upgrader --help >/dev/null
 MAIN_REPO_ROOT="$(dirname "$(git rev-parse --git-common-dir)")"
 GIT_DIR_PATH="$(git rev-parse --git-dir)"
 MAKE_DIR=".make"
+STAMP_FILE="${MAKE_DIR}/template-parent-sha"
 TEMPLATE_BRANCH="${COOKIECUTTER_TEMPLATE_BRANCH:-cookiecutter-template}"
-TEMPLATE_PARENT_SHA_FILE=".make/template-parent-sha"
 TEMPLATE_UPGRADE_BRANCH="${COOKIECUTTER_TEMPLATE_UPGRADE_BRANCH:-main}"
-RBS_HIDDEN=0
-RUBOCOP_MAIN_HIDDEN=0
-RUBOCOP_CWD_HIDDEN=0
 GIT_WORKTREE_SHIM=0
 REPO_CWD="$(pwd)"
+HIDDEN_BACKUPS=()
+
+hide_for_bake() {
+  local src=$1 bak=$2
+  if [ -f "${src}" ]; then
+    mv "${src}" "${bak}"
+    HIDDEN_BACKUPS+=("${bak}|${src}")
+  fi
+}
+
+restore_hidden() {
+  local entry bak dest
+  for entry in "${HIDDEN_BACKUPS[@]}"; do
+    bak="${entry%%|*}"
+    dest="${entry#*|}"
+    [ -f "${bak}" ] && mv "${bak}" "${dest}"
+  done
+  HIDDEN_BACKUPS=()
+}
 
 cleanup_prepare() {
   if [ "${GIT_WORKTREE_SHIM}" -eq 1 ] && [ -f "${MAKE_DIR}/git-worktree-pointer" ]; then
@@ -25,24 +41,8 @@ cleanup_prepare() {
     mv "${MAKE_DIR}/git-worktree-pointer" .git
     GIT_WORKTREE_SHIM=0
   fi
-  if [ "${RBS_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rbs_collection.yaml.bak" ]; then
-    mv "${MAKE_DIR}/rbs_collection.yaml.bak" "${MAIN_REPO_ROOT}/rbs_collection.yaml"
-    rm -f "${MAKE_DIR}/rbs_collection_yaml_hidden"
-    RBS_HIDDEN=0
-  fi
-  if [ "${RUBOCOP_MAIN_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rubocop-main.yml.bak" ]; then
-    mv "${MAKE_DIR}/rubocop-main.yml.bak" "${MAIN_REPO_ROOT}/.rubocop.yml"
-    rm -f "${MAKE_DIR}/rubocop_main_hidden"
-    RUBOCOP_MAIN_HIDDEN=0
-  fi
-  if [ "${RUBOCOP_CWD_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rubocop-cwd.yml.bak" ]; then
-    mv "${MAKE_DIR}/rubocop-cwd.yml.bak" "${REPO_CWD}/.rubocop.yml"
-    rm -f "${MAKE_DIR}/rubocop_cwd_hidden"
-    RUBOCOP_CWD_HIDDEN=0
-  fi
-  if [ -d "${GIT_DIR_PATH}/cookiecutter" ]; then
-    rm -rf "${GIT_DIR_PATH}/cookiecutter"
-  fi
+  restore_hidden
+  [ -d "${GIT_DIR_PATH}/cookiecutter" ] && rm -rf "${GIT_DIR_PATH}/cookiecutter"
 }
 
 trap cleanup_prepare EXIT
@@ -50,146 +50,107 @@ trap cleanup_prepare EXIT
 mkdir -p "${MAKE_DIR}"
 
 CONTEXT_FILE="${MAKE_DIR}/cookiecutter_context.json"
+TEMPLATE_URL=""
 if [ -f docs/cookiecutter_input.json ]; then
   jq 'del(._output_dir, ._repo_dir, ._checkout)' docs/cookiecutter_input.json \
     > "${CONTEXT_FILE}"
+  TEMPLATE_URL="$(jq -r '._template // empty' "${CONTEXT_FILE}")"
 fi
 
-template_url_from_context() {
-  jq -r '._template // empty' "${CONTEXT_FILE}"
-}
-
 cookiecutter_cache_dir() {
-  local template_url=$1
-  local repo_name=""
-
-  if [[ "${template_url}" =~ github\.com[:/][^/]+/([^/.]+)(\.git)?/?$ ]]; then
-    repo_name="${BASH_REMATCH[1]}"
-  elif [[ "${template_url}" =~ ^git@github\.com:[^/]+/([^/.]+)(\.git)?$ ]]; then
-    repo_name="${BASH_REMATCH[1]}"
+  local url=$1 name=""
+  if [[ "${url}" =~ github\.com[:/][^/]+/([^/.]+) ]]; then
+    name="${BASH_REMATCH[1]}"
+  elif [[ "${url}" =~ ^git@github\.com:[^/]+/([^/.]+) ]]; then
+    name="${BASH_REMATCH[1]}"
   else
     return 1
   fi
-
-  echo "${HOME}/.cookiecutters/${repo_name}"
+  printf '%s\n' "${HOME}/.cookiecutters/${name}"
 }
 
 refresh_template_cache() {
-  local template_url=$1
-  local upgrade_branch=$2
-  local cache_dir=""
-
-  if ! cache_dir="$(cookiecutter_cache_dir "${template_url}")"; then
-    echo "warning: could not derive cookiecutter cache dir from template URL: ${template_url}" >&2
+  local url=$1 branch=$2 cache=""
+  cache="$(cookiecutter_cache_dir "${url}")" || {
+    echo "warning: could not derive cookiecutter cache dir from: ${url}" >&2
+    return 0
+  }
+  if [ ! -d "${cache}/.git" ]; then
+    echo "cookiecutter cache not present at ${cache}; clone on bake" >&2
     return 0
   fi
-
-  if [ ! -d "${cache_dir}/.git" ]; then
-    echo "cookiecutter cache not present yet at ${cache_dir}; cookiecutter will clone on bake" >&2
-    return 0
-  fi
-
-  echo "Refreshing cookiecutter template cache ${cache_dir} @ ${upgrade_branch}"
-  git -C "${cache_dir}" fetch origin "${upgrade_branch}"
-  git -C "${cache_dir}" checkout "${upgrade_branch}"
-  git -C "${cache_dir}" merge --ff-only "origin/${upgrade_branch}"
+  echo "Refreshing cookiecutter cache ${cache} @ ${branch}"
+  git -C "${cache}" fetch origin "${branch}"
+  git -C "${cache}" checkout "${branch}"
+  git -C "${cache}" merge --ff-only "origin/${branch}"
 }
 
 resolve_template_parent_sha() {
-  local template_url=$1
-  local upgrade_branch=$2
-
-  if git remote get-url cookiecutter-upstream >/dev/null 2>&1; then
-    git fetch cookiecutter-upstream "${upgrade_branch}"
-    git rev-parse "cookiecutter-upstream/${upgrade_branch}"
+  local url=$1 branch=$2 cache=""
+  if git remote get-url cookiecutter-upstream &>/dev/null; then
+    git fetch cookiecutter-upstream "${branch}"
+    git rev-parse "cookiecutter-upstream/${branch}"
     return 0
   fi
-
-  local cache_dir=""
-  if cache_dir="$(cookiecutter_cache_dir "${template_url}")" && [ -d "${cache_dir}/.git" ]; then
-    git -C "${cache_dir}" rev-parse "origin/${upgrade_branch}"
+  if cache="$(cookiecutter_cache_dir "${url}")" && [ -d "${cache}/.git" ]; then
+    git -C "${cache}" rev-parse "origin/${branch}"
     return 0
   fi
-
-  git fetch origin "${upgrade_branch}"
-  git rev-parse "origin/${upgrade_branch}"
+  git fetch origin "${branch}"
+  git rev-parse "origin/${branch}"
 }
 
 read_template_parent_stamp() {
-  if git rev-parse --verify "${TEMPLATE_BRANCH}" >/dev/null 2>&1; then
-    git show "${TEMPLATE_BRANCH}:${TEMPLATE_PARENT_SHA_FILE}" 2>/dev/null | tr -d '[:space:]' || true
-  fi
+  git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null \
+    || return 0
+  git show "${TEMPLATE_BRANCH}:${STAMP_FILE}" 2>/dev/null | tr -d '[:space:]' || true
 }
 
 stamp_template_parent_sha() {
-  local parent_sha=$1
-  local stamp_worktree=""
+  local parent_sha=$1 wt=""
+  wt="$(mktemp -d)"
+  trap 'git worktree remove --force "${wt}" &>/dev/null; rm -rf "${wt}"' RETURN
 
-  stamp_worktree="$(mktemp -d)"
-  cleanup_stamp_worktree() {
-    git worktree remove --force "${stamp_worktree}" >/dev/null 2>&1 || true
-    rm -rf "${stamp_worktree}"
-  }
-  trap cleanup_stamp_worktree RETURN
-
-  git worktree add --detach "${stamp_worktree}" "${TEMPLATE_BRANCH}"
-  mkdir -p "${stamp_worktree}/.make"
-  printf '%s\n' "${parent_sha}" > "${stamp_worktree}/${TEMPLATE_PARENT_SHA_FILE}"
-  if git -C "${stamp_worktree}" diff --quiet -- "${TEMPLATE_PARENT_SHA_FILE}"; then
-    echo "template-parent-sha already recorded on ${TEMPLATE_BRANCH}"
+  git worktree add --detach "${wt}" "${TEMPLATE_BRANCH}"
+  mkdir -p "${wt}/${MAKE_DIR}"
+  printf '%s\n' "${parent_sha}" > "${wt}/${STAMP_FILE}"
+  if git -C "${wt}" diff --quiet -- "${STAMP_FILE}"; then
+    echo "template-parent-sha already on ${TEMPLATE_BRANCH}"
     return 0
   fi
-  git -C "${stamp_worktree}" add "${TEMPLATE_PARENT_SHA_FILE}"
-  git -C "${stamp_worktree}" commit -m "Record template parent SHA ${parent_sha:0:12}"
+  git -C "${wt}" add "${STAMP_FILE}"
+  git -C "${wt}" commit -m "Record template parent SHA ${parent_sha:0:12}"
   git push origin "HEAD:${TEMPLATE_BRANCH}"
 }
 
 verify_template_branch_freshness() {
-  local parent_sha=$1
-  local tip_before=$2
-  local tip_after=$3
-  local stamp=""
-
+  local parent_sha=$1 tip_before=$2 tip_after=$3 stamp=""
   stamp="$(read_template_parent_stamp)"
+
   if [ "${tip_before}" != "${tip_after}" ]; then
-    if [ "${stamp}" != "${parent_sha}" ]; then
-      stamp_template_parent_sha "${parent_sha}"
-    fi
-    echo "Re-baked ${TEMPLATE_BRANCH}: ${tip_before:0:12} -> ${tip_after:0:12} @ parent ${parent_sha:0:12}"
+    [ "${stamp}" != "${parent_sha}" ] && stamp_template_parent_sha "${parent_sha}"
+    echo "Re-baked ${TEMPLATE_BRANCH}: ${tip_before:0:12} -> ${tip_after:0:12} @ ${parent_sha:0:12}"
     return 0
   fi
-
   if [ "${stamp}" = "${parent_sha}" ]; then
-    echo "Template branch already matches parent ${parent_sha:0:12}; continuing idempotently"
+    echo "Template branch matches parent ${parent_sha:0:12}; idempotent"
     return 0
   fi
 
-  >&2 echo "error: ${TEMPLATE_BRANCH} tip unchanged (${tip_after:0:12}) but parent is ${parent_sha:0:12}"
-  >&2 echo "       recorded stamp: ${stamp:-<missing>}"
-  >&2 echo "       Refresh failed or bake used stale template cache; fix cache/upstream and retry."
+  >&2 cat <<EOF
+error: ${TEMPLATE_BRANCH} tip unchanged (${tip_after:0:12}) but parent is ${parent_sha:0:12}
+       recorded stamp: ${stamp:-<missing>}
+       Refresh failed or bake used stale cache; fix upstream/cache and retry.
+EOF
   exit 1
 }
 
-if [ -f "${MAIN_REPO_ROOT}/rbs_collection.yaml" ]; then
-  mv "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
-  touch "${MAKE_DIR}/rbs_collection_yaml_hidden"
-  RBS_HIDDEN=1
-fi
-if [ -f "${MAIN_REPO_ROOT}/.rubocop.yml" ]; then
-  mv "${MAIN_REPO_ROOT}/.rubocop.yml" "${MAKE_DIR}/rubocop-main.yml.bak"
-  touch "${MAKE_DIR}/rubocop_main_hidden"
-  RUBOCOP_MAIN_HIDDEN=1
-fi
-# Nested tiers may have their own .rubocop.yml; hide it so RuboCop does not inherit
-# mismatched config while cookiecutter_project_upgrader runs under .git/cookiecutter/
-if [ -f "${REPO_CWD}/.rubocop.yml" ]; then
-  mv "${REPO_CWD}/.rubocop.yml" "${MAKE_DIR}/rubocop-cwd.yml.bak"
-  touch "${MAKE_DIR}/rubocop_cwd_hidden"
-  RUBOCOP_CWD_HIDDEN=1
-fi
+hide_for_bake "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
+hide_for_bake "${MAIN_REPO_ROOT}/.rubocop.yml" "${MAKE_DIR}/rubocop-main.yml.bak"
+hide_for_bake "${REPO_CWD}/.rubocop.yml" "${MAKE_DIR}/rubocop-cwd.yml.bak"
 
-if [ -f .make/git-worktree-pointer ] && [ ! -f .git ] && [ ! -L .git ]; then
-  echo "error: stale ${MAKE_DIR}/git-worktree-pointer but .git is missing; restore manually" >&2
+if [ -f .make/git-worktree-pointer ] && [ ! -e .git ]; then
+  echo "error: stale ${MAKE_DIR}/git-worktree-pointer but .git missing" >&2
   exit 1
 fi
 
@@ -203,55 +164,47 @@ elif [ -f .git ] && [ ! -L .git ]; then
   exit 1
 fi
 
-TEMPLATE_URL=""
-if [ -f "${CONTEXT_FILE}" ]; then
-  TEMPLATE_URL="$(template_url_from_context)"
-fi
-if [ -n "${TEMPLATE_URL}" ]; then
-  refresh_template_cache "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}"
-fi
+[ -n "${TEMPLATE_URL}" ] && refresh_template_cache "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}"
 PARENT_SHA="$(resolve_template_parent_sha "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}")"
 echo "Template parent SHA (${TEMPLATE_UPGRADE_BRANCH}): ${PARENT_SHA}"
 
-if git rev-parse --verify "${TEMPLATE_BRANCH}" >/dev/null 2>&1; then
+TEMPLATE_TIP_BEFORE=""
+if git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null; then
   TEMPLATE_TIP_BEFORE="$(git rev-parse "${TEMPLATE_BRANCH}")"
-else
-  TEMPLATE_TIP_BEFORE=""
 fi
 
 export IN_COOKIECUTTER_PROJECT_UPGRADER=1
 UPGRADER_ARGS=(-p true -u "${TEMPLATE_UPGRADE_BRANCH}")
-if [ -f "${CONTEXT_FILE}" ]; then
-  UPGRADER_ARGS=(-c "${CONTEXT_FILE}" "${UPGRADER_ARGS[@]}")
-fi
+[ -f "${CONTEXT_FILE}" ] && UPGRADER_ARGS=(-c "${CONTEXT_FILE}" "${UPGRADER_ARGS[@]}")
 if ! cookiecutter_project_upgrader "${UPGRADER_ARGS[@]}"; then
-  if [ -z "${TEMPLATE_TIP_BEFORE}" ] || ! git rev-parse --verify "${TEMPLATE_BRANCH}" >/dev/null 2>&1; then
-    >&2 echo "error: cookiecutter_project_upgrader failed and ${TEMPLATE_BRANCH} is missing"
+  if [ -z "${TEMPLATE_TIP_BEFORE}" ] \
+    || ! git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null; then
+    >&2 echo "error: upgrader failed and ${TEMPLATE_BRANCH} is missing"
     exit 1
   fi
   echo "cookiecutter_project_upgrader reported no template diff; checking parent SHA stamp"
 fi
 
-TEMPLATE_TIP_AFTER="$(git rev-parse "${TEMPLATE_BRANCH}")"
-verify_template_branch_freshness "${PARENT_SHA}" "${TEMPLATE_TIP_BEFORE}" "${TEMPLATE_TIP_AFTER}"
+verify_template_branch_freshness "${PARENT_SHA}" "${TEMPLATE_TIP_BEFORE}" \
+  "$(git rev-parse "${TEMPLATE_BRANCH}")"
 
 trap - EXIT
 cleanup_prepare
 
-# Finish phase (worktree-safe: no checkout of branches locked in other worktrees)
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
-if git symbolic-ref -q "refs/remotes/origin/HEAD" >/dev/null 2>&1; then
+if git symbolic-ref -q refs/remotes/origin/HEAD &>/dev/null; then
   DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')"
 fi
 
-if ! git diff --quiet -- Makefile 2>/dev/null || ! git diff --cached --quiet -- Makefile 2>/dev/null; then
+if ! git diff --quiet -- Makefile 2>/dev/null \
+  || ! git diff --cached --quiet -- Makefile 2>/dev/null; then
   git stash push -m 'update_from_cookiecutter Makefile' -- Makefile
   touch "${MAKE_DIR}/cookiecutter_makefile_stashed"
 fi
 
 git push --no-verify origin "${TEMPLATE_BRANCH}"
+git fetch origin "${DEFAULT_BRANCH}"
 
-git fetch "origin" "${DEFAULT_BRANCH}"
 UPDATE_BRANCH="update-from-cookiecutter-$(date +%Y-%m-%d-%H%M)"
 git switch -c "${UPDATE_BRANCH}" "origin/${DEFAULT_BRANCH}"
 echo "Created branch ${UPDATE_BRANCH} from origin/${DEFAULT_BRANCH}"
@@ -272,8 +225,10 @@ bundle update --conservative json rexml || true
 ( make build && git add Gemfile.lock ) || true
 bin/overcommit --install || true
 
-echo
-echo "Please resolve any merge conflicts below and push up a PR with:"
-echo
-echo '   gh pr create --title "Update from upstream" --body "Automated PR to update from upstream boilerplate"'
-echo
+cat <<'EOF'
+
+Please resolve any merge conflicts below and push up a PR with:
+
+   gh pr create --title "Update from upstream" --body "Automated PR to update from upstream boilerplate"
+
+EOF

--- a/bin/cookiecutter_project_upgrader.sh
+++ b/bin/cookiecutter_project_upgrader.sh
@@ -125,7 +125,7 @@ stamp_template_parent_sha() {
   local parent_sha=$1
   local stamp_worktree=""
 
-  stamp_worktree="$(mktemp -d "${TMPDIR:-/tmp}/cookiecutter-template-stamp.XXXXXX")"
+  stamp_worktree="$(mktemp -d)"
   cleanup_stamp_worktree() {
     git worktree remove --force "${stamp_worktree}" >/dev/null 2>&1 || true
     rm -rf "${stamp_worktree}"

--- a/bin/cookiecutter_project_upgrader.sh
+++ b/bin/cookiecutter_project_upgrader.sh
@@ -69,35 +69,38 @@ cookiecutter_cache_dir() {
   printf '%s\n' "${HOME}/.cookiecutters/${name}"
 }
 
-refresh_template_cache() {
-  local url=$1 branch=$2 cache=""
-  cache="$(cookiecutter_cache_dir "${url}")" || {
-    echo "warning: could not derive cookiecutter cache dir from: ${url}" >&2
-    return 0
-  }
-  if [ ! -d "${cache}/.git" ]; then
-    echo "cookiecutter cache not present at ${cache}; clone on bake" >&2
-    return 0
+wipe_template_cache() {
+  local url=$1 cache=""
+  cache="$(cookiecutter_cache_dir "${url}")" || return 0
+  if [ -e "${cache}" ]; then
+    echo "Removing cookiecutter cache ${cache}"
+    rm -rf "${cache}"
   fi
-  echo "Refreshing cookiecutter cache ${cache} @ ${branch}"
-  git -C "${cache}" fetch origin "${branch}"
-  git -C "${cache}" checkout "${branch}"
-  git -C "${cache}" merge --ff-only "origin/${branch}"
 }
 
 resolve_template_parent_sha() {
-  local url=$1 branch=$2 cache=""
+  local url=$1 branch=$2 cache="" sha=""
   if git remote get-url cookiecutter-upstream &>/dev/null; then
     git fetch cookiecutter-upstream "${branch}"
     git rev-parse "cookiecutter-upstream/${branch}"
     return 0
   fi
   if cache="$(cookiecutter_cache_dir "${url}")" && [ -d "${cache}/.git" ]; then
-    git -C "${cache}" rev-parse "origin/${branch}"
+    git -C "${cache}" rev-parse "${branch}" 2>/dev/null \
+      || git -C "${cache}" rev-parse "origin/${branch}"
     return 0
   fi
-  git fetch origin "${branch}"
-  git rev-parse "origin/${branch}"
+  if [ -n "${url}" ]; then
+    sha="$(git ls-remote "${url}" "refs/heads/${branch}" | awk 'NR==1 { print $1; exit }')"
+    [ -n "${sha}" ] || {
+      echo "error: could not resolve parent SHA for ${url} @ ${branch}" >&2
+      return 1
+    }
+    printf '%s\n' "${sha}"
+    return 0
+  fi
+  echo "error: no template URL or cookiecutter-upstream for parent SHA" >&2
+  return 1
 }
 
 read_template_parent_stamp() {
@@ -140,7 +143,7 @@ verify_template_branch_freshness() {
   >&2 cat <<EOF
 error: ${TEMPLATE_BRANCH} tip unchanged (${tip_after:0:12}) but parent is ${parent_sha:0:12}
        recorded stamp: ${stamp:-<missing>}
-       Refresh failed or bake used stale cache; fix upstream/cache and retry.
+       Wipe cache and retry, or check cookiecutter-upstream / template URL.
 EOF
   exit 1
 }
@@ -164,9 +167,7 @@ elif [ -f .git ] && [ ! -L .git ]; then
   exit 1
 fi
 
-[ -n "${TEMPLATE_URL}" ] && refresh_template_cache "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}"
-PARENT_SHA="$(resolve_template_parent_sha "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}")"
-echo "Template parent SHA (${TEMPLATE_UPGRADE_BRANCH}): ${PARENT_SHA}"
+[ -n "${TEMPLATE_URL}" ] && wipe_template_cache "${TEMPLATE_URL}"
 
 TEMPLATE_TIP_BEFORE=""
 if git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null; then
@@ -184,6 +185,9 @@ if ! cookiecutter_project_upgrader "${UPGRADER_ARGS[@]}"; then
   fi
   echo "cookiecutter_project_upgrader reported no template diff; checking parent SHA stamp"
 fi
+
+PARENT_SHA="$(resolve_template_parent_sha "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}")"
+echo "Template parent SHA (${TEMPLATE_UPGRADE_BRANCH}): ${PARENT_SHA}"
 
 verify_template_branch_freshness "${PARENT_SHA}" "${TEMPLATE_TIP_BEFORE}" \
   "$(git rev-parse "${TEMPLATE_BRANCH}")"

--- a/bin/cookiecutter_project_upgrader.sh
+++ b/bin/cookiecutter_project_upgrader.sh
@@ -103,12 +103,6 @@ resolve_template_parent_sha() {
   return 1
 }
 
-read_template_parent_stamp() {
-  git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null \
-    || return 0
-  git show "${TEMPLATE_BRANCH}:${STAMP_FILE}" 2>/dev/null | tr -d '[:space:]' || true
-}
-
 stamp_template_parent_sha() {
   local parent_sha=$1 wt=""
   wt="$(mktemp -d)"
@@ -124,28 +118,6 @@ stamp_template_parent_sha() {
   git -C "${wt}" add "${STAMP_FILE}"
   git -C "${wt}" commit -m "Record template parent SHA ${parent_sha:0:12}"
   git push origin "HEAD:${TEMPLATE_BRANCH}"
-}
-
-verify_template_branch_freshness() {
-  local parent_sha=$1 tip_before=$2 tip_after=$3 stamp=""
-  stamp="$(read_template_parent_stamp)"
-
-  if [ "${tip_before}" != "${tip_after}" ]; then
-    [ "${stamp}" != "${parent_sha}" ] && stamp_template_parent_sha "${parent_sha}"
-    echo "Re-baked ${TEMPLATE_BRANCH}: ${tip_before:0:12} -> ${tip_after:0:12} @ ${parent_sha:0:12}"
-    return 0
-  fi
-  if [ "${stamp}" = "${parent_sha}" ]; then
-    echo "Template branch matches parent ${parent_sha:0:12}; idempotent"
-    return 0
-  fi
-
-  >&2 cat <<EOF
-error: ${TEMPLATE_BRANCH} tip unchanged (${tip_after:0:12}) but parent is ${parent_sha:0:12}
-       recorded stamp: ${stamp:-<missing>}
-       Wipe cache and retry, or check cookiecutter-upstream / template URL.
-EOF
-  exit 1
 }
 
 hide_for_bake "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
@@ -169,28 +141,20 @@ fi
 
 [ -n "${TEMPLATE_URL}" ] && wipe_template_cache "${TEMPLATE_URL}"
 
-TEMPLATE_TIP_BEFORE=""
-if git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null; then
-  TEMPLATE_TIP_BEFORE="$(git rev-parse "${TEMPLATE_BRANCH}")"
-fi
-
 export IN_COOKIECUTTER_PROJECT_UPGRADER=1
 UPGRADER_ARGS=(-p true -u "${TEMPLATE_UPGRADE_BRANCH}")
 [ -f "${CONTEXT_FILE}" ] && UPGRADER_ARGS=(-c "${CONTEXT_FILE}" "${UPGRADER_ARGS[@]}")
 if ! cookiecutter_project_upgrader "${UPGRADER_ARGS[@]}"; then
-  if [ -z "${TEMPLATE_TIP_BEFORE}" ] \
-    || ! git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null; then
+  if ! git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null; then
     >&2 echo "error: upgrader failed and ${TEMPLATE_BRANCH} is missing"
     exit 1
   fi
-  echo "cookiecutter_project_upgrader reported no template diff; checking parent SHA stamp"
+  echo "cookiecutter_project_upgrader reported no template diff"
 fi
 
 PARENT_SHA="$(resolve_template_parent_sha "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}")"
 echo "Template parent SHA (${TEMPLATE_UPGRADE_BRANCH}): ${PARENT_SHA}"
-
-verify_template_branch_freshness "${PARENT_SHA}" "${TEMPLATE_TIP_BEFORE}" \
-  "$(git rev-parse "${TEMPLATE_BRANCH}")"
+stamp_template_parent_sha "${PARENT_SHA}"
 
 trap - EXIT
 cleanup_prepare

--- a/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
+++ b/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
@@ -10,7 +10,6 @@ cookiecutter_project_upgrader --help >/dev/null
 MAIN_REPO_ROOT="$(dirname "$(git rev-parse --git-common-dir)")"
 GIT_DIR_PATH="$(git rev-parse --git-dir)"
 MAKE_DIR=".make"
-STAMP_FILE="${MAKE_DIR}/template-parent-sha"
 TEMPLATE_BRANCH="${COOKIECUTTER_TEMPLATE_BRANCH:-cookiecutter-template}"
 TEMPLATE_UPGRADE_BRANCH="${COOKIECUTTER_TEMPLATE_UPGRADE_BRANCH:-main}"
 GIT_WORKTREE_SHIM=0
@@ -78,48 +77,6 @@ wipe_template_cache() {
   fi
 }
 
-resolve_template_parent_sha() {
-  local url=$1 branch=$2 cache="" sha=""
-  if git remote get-url cookiecutter-upstream &>/dev/null; then
-    git fetch cookiecutter-upstream "${branch}"
-    git rev-parse "cookiecutter-upstream/${branch}"
-    return 0
-  fi
-  if cache="$(cookiecutter_cache_dir "${url}")" && [ -d "${cache}/.git" ]; then
-    git -C "${cache}" rev-parse "${branch}" 2>/dev/null \
-      || git -C "${cache}" rev-parse "origin/${branch}"
-    return 0
-  fi
-  if [ -n "${url}" ]; then
-    sha="$(git ls-remote "${url}" "refs/heads/${branch}" | awk 'NR==1 { print $1; exit }')"
-    [ -n "${sha}" ] || {
-      echo "error: could not resolve parent SHA for ${url} @ ${branch}" >&2
-      return 1
-    }
-    printf '%s\n' "${sha}"
-    return 0
-  fi
-  echo "error: no template URL or cookiecutter-upstream for parent SHA" >&2
-  return 1
-}
-
-stamp_template_parent_sha() {
-  local parent_sha=$1 wt=""
-  wt="$(mktemp -d)"
-  trap 'git worktree remove --force "${wt}" &>/dev/null; rm -rf "${wt}"' RETURN
-
-  git worktree add --detach "${wt}" "${TEMPLATE_BRANCH}"
-  mkdir -p "${wt}/${MAKE_DIR}"
-  printf '%s\n' "${parent_sha}" > "${wt}/${STAMP_FILE}"
-  if git -C "${wt}" diff --quiet -- "${STAMP_FILE}"; then
-    echo "template-parent-sha already on ${TEMPLATE_BRANCH}"
-    return 0
-  fi
-  git -C "${wt}" add "${STAMP_FILE}"
-  git -C "${wt}" commit -m "Record template parent SHA ${parent_sha:0:12}"
-  git push origin "HEAD:${TEMPLATE_BRANCH}"
-}
-
 hide_for_bake "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
 hide_for_bake "${MAIN_REPO_ROOT}/.rubocop.yml" "${MAKE_DIR}/rubocop-main.yml.bak"
 hide_for_bake "${REPO_CWD}/.rubocop.yml" "${MAKE_DIR}/rubocop-cwd.yml.bak"
@@ -151,10 +108,6 @@ if ! cookiecutter_project_upgrader "${UPGRADER_ARGS[@]}"; then
   fi
   echo "cookiecutter_project_upgrader reported no template diff"
 fi
-
-PARENT_SHA="$(resolve_template_parent_sha "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}")"
-echo "Template parent SHA (${TEMPLATE_UPGRADE_BRANCH}): ${PARENT_SHA}"
-stamp_template_parent_sha "${PARENT_SHA}"
 
 trap - EXIT
 cleanup_prepare

--- a/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
+++ b/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
@@ -10,6 +10,9 @@ cookiecutter_project_upgrader --help >/dev/null
 MAIN_REPO_ROOT="$(dirname "$(git rev-parse --git-common-dir)")"
 GIT_DIR_PATH="$(git rev-parse --git-dir)"
 MAKE_DIR=".make"
+TEMPLATE_BRANCH="${COOKIECUTTER_TEMPLATE_BRANCH:-cookiecutter-template}"
+TEMPLATE_PARENT_SHA_FILE=".make/template-parent-sha"
+TEMPLATE_UPGRADE_BRANCH="${COOKIECUTTER_TEMPLATE_UPGRADE_BRANCH:-main}"
 RBS_HIDDEN=0
 RUBOCOP_MAIN_HIDDEN=0
 RUBOCOP_CWD_HIDDEN=0
@@ -46,10 +49,126 @@ trap cleanup_prepare EXIT
 
 mkdir -p "${MAKE_DIR}"
 
+CONTEXT_FILE="${MAKE_DIR}/cookiecutter_context.json"
 if [ -f docs/cookiecutter_input.json ]; then
   jq 'del(._output_dir, ._repo_dir, ._checkout)' docs/cookiecutter_input.json \
-    > "${MAKE_DIR}/cookiecutter_context.json"
+    > "${CONTEXT_FILE}"
 fi
+
+template_url_from_context() {
+  jq -r '._template // empty' "${CONTEXT_FILE}"
+}
+
+cookiecutter_cache_dir() {
+  local template_url=$1
+  local repo_name=""
+
+  if [[ "${template_url}" =~ github\.com[:/][^/]+/([^/.]+)(\.git)?/?$ ]]; then
+    repo_name="${BASH_REMATCH[1]}"
+  elif [[ "${template_url}" =~ ^git@github\.com:[^/]+/([^/.]+)(\.git)?$ ]]; then
+    repo_name="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+
+  echo "${HOME}/.cookiecutters/${repo_name}"
+}
+
+refresh_template_cache() {
+  local template_url=$1
+  local upgrade_branch=$2
+  local cache_dir=""
+
+  if ! cache_dir="$(cookiecutter_cache_dir "${template_url}")"; then
+    echo "warning: could not derive cookiecutter cache dir from template URL: ${template_url}" >&2
+    return 0
+  fi
+
+  if [ ! -d "${cache_dir}/.git" ]; then
+    echo "cookiecutter cache not present yet at ${cache_dir}; cookiecutter will clone on bake" >&2
+    return 0
+  fi
+
+  echo "Refreshing cookiecutter template cache ${cache_dir} @ ${upgrade_branch}"
+  git -C "${cache_dir}" fetch origin "${upgrade_branch}"
+  git -C "${cache_dir}" checkout "${upgrade_branch}"
+  git -C "${cache_dir}" merge --ff-only "origin/${upgrade_branch}"
+}
+
+resolve_template_parent_sha() {
+  local template_url=$1
+  local upgrade_branch=$2
+
+  if git remote get-url cookiecutter-upstream >/dev/null 2>&1; then
+    git fetch cookiecutter-upstream "${upgrade_branch}"
+    git rev-parse "cookiecutter-upstream/${upgrade_branch}"
+    return 0
+  fi
+
+  local cache_dir=""
+  if cache_dir="$(cookiecutter_cache_dir "${template_url}")" && [ -d "${cache_dir}/.git" ]; then
+    git -C "${cache_dir}" rev-parse "origin/${upgrade_branch}"
+    return 0
+  fi
+
+  git fetch origin "${upgrade_branch}"
+  git rev-parse "origin/${upgrade_branch}"
+}
+
+read_template_parent_stamp() {
+  if git rev-parse --verify "${TEMPLATE_BRANCH}" >/dev/null 2>&1; then
+    git show "${TEMPLATE_BRANCH}:${TEMPLATE_PARENT_SHA_FILE}" 2>/dev/null | tr -d '[:space:]' || true
+  fi
+}
+
+stamp_template_parent_sha() {
+  local parent_sha=$1
+  local stamp_worktree=""
+
+  stamp_worktree="$(mktemp -d "${TMPDIR:-/tmp}/cookiecutter-template-stamp.XXXXXX")"
+  cleanup_stamp_worktree() {
+    git worktree remove --force "${stamp_worktree}" >/dev/null 2>&1 || true
+    rm -rf "${stamp_worktree}"
+  }
+  trap cleanup_stamp_worktree RETURN
+
+  git worktree add --detach "${stamp_worktree}" "${TEMPLATE_BRANCH}"
+  mkdir -p "${stamp_worktree}/.make"
+  printf '%s\n' "${parent_sha}" > "${stamp_worktree}/${TEMPLATE_PARENT_SHA_FILE}"
+  if git -C "${stamp_worktree}" diff --quiet -- "${TEMPLATE_PARENT_SHA_FILE}"; then
+    echo "template-parent-sha already recorded on ${TEMPLATE_BRANCH}"
+    return 0
+  fi
+  git -C "${stamp_worktree}" add "${TEMPLATE_PARENT_SHA_FILE}"
+  git -C "${stamp_worktree}" commit -m "Record template parent SHA ${parent_sha:0:12}"
+  git push origin "HEAD:${TEMPLATE_BRANCH}"
+}
+
+verify_template_branch_freshness() {
+  local parent_sha=$1
+  local tip_before=$2
+  local tip_after=$3
+  local stamp=""
+
+  stamp="$(read_template_parent_stamp)"
+  if [ "${tip_before}" != "${tip_after}" ]; then
+    if [ "${stamp}" != "${parent_sha}" ]; then
+      stamp_template_parent_sha "${parent_sha}"
+    fi
+    echo "Re-baked ${TEMPLATE_BRANCH}: ${tip_before:0:12} -> ${tip_after:0:12} @ parent ${parent_sha:0:12}"
+    return 0
+  fi
+
+  if [ "${stamp}" = "${parent_sha}" ]; then
+    echo "Template branch already matches parent ${parent_sha:0:12}; continuing idempotently"
+    return 0
+  fi
+
+  >&2 echo "error: ${TEMPLATE_BRANCH} tip unchanged (${tip_after:0:12}) but parent is ${parent_sha:0:12}"
+  >&2 echo "       recorded stamp: ${stamp:-<missing>}"
+  >&2 echo "       Refresh failed or bake used stale template cache; fix cache/upstream and retry."
+  exit 1
+}
 
 if [ -f "${MAIN_REPO_ROOT}/rbs_collection.yaml" ]; then
   mv "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
@@ -84,12 +203,37 @@ elif [ -f .git ] && [ ! -L .git ]; then
   exit 1
 fi
 
-export IN_COOKIECUTTER_PROJECT_UPGRADER=1
-if [ -f "${MAKE_DIR}/cookiecutter_context.json" ]; then
-  cookiecutter_project_upgrader -c "${MAKE_DIR}/cookiecutter_context.json" -p true
-else
-  cookiecutter_project_upgrader
+TEMPLATE_URL=""
+if [ -f "${CONTEXT_FILE}" ]; then
+  TEMPLATE_URL="$(template_url_from_context)"
 fi
+if [ -n "${TEMPLATE_URL}" ]; then
+  refresh_template_cache "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}"
+fi
+PARENT_SHA="$(resolve_template_parent_sha "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}")"
+echo "Template parent SHA (${TEMPLATE_UPGRADE_BRANCH}): ${PARENT_SHA}"
+
+if git rev-parse --verify "${TEMPLATE_BRANCH}" >/dev/null 2>&1; then
+  TEMPLATE_TIP_BEFORE="$(git rev-parse "${TEMPLATE_BRANCH}")"
+else
+  TEMPLATE_TIP_BEFORE=""
+fi
+
+export IN_COOKIECUTTER_PROJECT_UPGRADER=1
+UPGRADER_ARGS=(-p true -u "${TEMPLATE_UPGRADE_BRANCH}")
+if [ -f "${CONTEXT_FILE}" ]; then
+  UPGRADER_ARGS=(-c "${CONTEXT_FILE}" "${UPGRADER_ARGS[@]}")
+fi
+if ! cookiecutter_project_upgrader "${UPGRADER_ARGS[@]}"; then
+  if [ -z "${TEMPLATE_TIP_BEFORE}" ] || ! git rev-parse --verify "${TEMPLATE_BRANCH}" >/dev/null 2>&1; then
+    >&2 echo "error: cookiecutter_project_upgrader failed and ${TEMPLATE_BRANCH} is missing"
+    exit 1
+  fi
+  echo "cookiecutter_project_upgrader reported no template diff; checking parent SHA stamp"
+fi
+
+TEMPLATE_TIP_AFTER="$(git rev-parse "${TEMPLATE_BRANCH}")"
+verify_template_branch_freshness "${PARENT_SHA}" "${TEMPLATE_TIP_BEFORE}" "${TEMPLATE_TIP_AFTER}"
 
 trap - EXIT
 cleanup_prepare
@@ -105,7 +249,7 @@ if ! git diff --quiet -- Makefile 2>/dev/null || ! git diff --cached --quiet -- 
   touch "${MAKE_DIR}/cookiecutter_makefile_stashed"
 fi
 
-git push --no-verify origin cookiecutter-template || true
+git push --no-verify origin "${TEMPLATE_BRANCH}"
 
 git fetch "origin" "${DEFAULT_BRANCH}"
 UPDATE_BRANCH="update-from-cookiecutter-$(date +%Y-%m-%d-%H%M)"
@@ -116,7 +260,7 @@ bin/overcommit --sign
 bin/overcommit --sign pre-commit
 bin/overcommit --sign pre-push
 
-git merge cookiecutter-template || true
+git merge "${TEMPLATE_BRANCH}"
 git checkout --ours Gemfile.lock || true
 
 if [ -f "${MAKE_DIR}/cookiecutter_makefile_stashed" ]; then
@@ -131,5 +275,5 @@ bin/overcommit --install || true
 echo
 echo "Please resolve any merge conflicts below and push up a PR with:"
 echo
-echo '   gh pr create --title "Update from cookiecutter" --body "Automated PR to update from cookiecutter boilerplate"'
+echo '   gh pr create --title "Update from upstream" --body "Automated PR to update from upstream boilerplate"'
 echo

--- a/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
+++ b/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
@@ -10,14 +10,30 @@ cookiecutter_project_upgrader --help >/dev/null
 MAIN_REPO_ROOT="$(dirname "$(git rev-parse --git-common-dir)")"
 GIT_DIR_PATH="$(git rev-parse --git-dir)"
 MAKE_DIR=".make"
+STAMP_FILE="${MAKE_DIR}/template-parent-sha"
 TEMPLATE_BRANCH="${COOKIECUTTER_TEMPLATE_BRANCH:-cookiecutter-template}"
-TEMPLATE_PARENT_SHA_FILE=".make/template-parent-sha"
 TEMPLATE_UPGRADE_BRANCH="${COOKIECUTTER_TEMPLATE_UPGRADE_BRANCH:-main}"
-RBS_HIDDEN=0
-RUBOCOP_MAIN_HIDDEN=0
-RUBOCOP_CWD_HIDDEN=0
 GIT_WORKTREE_SHIM=0
 REPO_CWD="$(pwd)"
+HIDDEN_BACKUPS=()
+
+hide_for_bake() {
+  local src=$1 bak=$2
+  if [ -f "${src}" ]; then
+    mv "${src}" "${bak}"
+    HIDDEN_BACKUPS+=("${bak}|${src}")
+  fi
+}
+
+restore_hidden() {
+  local entry bak dest
+  for entry in "${HIDDEN_BACKUPS[@]}"; do
+    bak="${entry%%|*}"
+    dest="${entry#*|}"
+    [ -f "${bak}" ] && mv "${bak}" "${dest}"
+  done
+  HIDDEN_BACKUPS=()
+}
 
 cleanup_prepare() {
   if [ "${GIT_WORKTREE_SHIM}" -eq 1 ] && [ -f "${MAKE_DIR}/git-worktree-pointer" ]; then
@@ -25,24 +41,8 @@ cleanup_prepare() {
     mv "${MAKE_DIR}/git-worktree-pointer" .git
     GIT_WORKTREE_SHIM=0
   fi
-  if [ "${RBS_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rbs_collection.yaml.bak" ]; then
-    mv "${MAKE_DIR}/rbs_collection.yaml.bak" "${MAIN_REPO_ROOT}/rbs_collection.yaml"
-    rm -f "${MAKE_DIR}/rbs_collection_yaml_hidden"
-    RBS_HIDDEN=0
-  fi
-  if [ "${RUBOCOP_MAIN_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rubocop-main.yml.bak" ]; then
-    mv "${MAKE_DIR}/rubocop-main.yml.bak" "${MAIN_REPO_ROOT}/.rubocop.yml"
-    rm -f "${MAKE_DIR}/rubocop_main_hidden"
-    RUBOCOP_MAIN_HIDDEN=0
-  fi
-  if [ "${RUBOCOP_CWD_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rubocop-cwd.yml.bak" ]; then
-    mv "${MAKE_DIR}/rubocop-cwd.yml.bak" "${REPO_CWD}/.rubocop.yml"
-    rm -f "${MAKE_DIR}/rubocop_cwd_hidden"
-    RUBOCOP_CWD_HIDDEN=0
-  fi
-  if [ -d "${GIT_DIR_PATH}/cookiecutter" ]; then
-    rm -rf "${GIT_DIR_PATH}/cookiecutter"
-  fi
+  restore_hidden
+  [ -d "${GIT_DIR_PATH}/cookiecutter" ] && rm -rf "${GIT_DIR_PATH}/cookiecutter"
 }
 
 trap cleanup_prepare EXIT
@@ -50,146 +50,107 @@ trap cleanup_prepare EXIT
 mkdir -p "${MAKE_DIR}"
 
 CONTEXT_FILE="${MAKE_DIR}/cookiecutter_context.json"
+TEMPLATE_URL=""
 if [ -f docs/cookiecutter_input.json ]; then
   jq 'del(._output_dir, ._repo_dir, ._checkout)' docs/cookiecutter_input.json \
     > "${CONTEXT_FILE}"
+  TEMPLATE_URL="$(jq -r '._template // empty' "${CONTEXT_FILE}")"
 fi
 
-template_url_from_context() {
-  jq -r '._template // empty' "${CONTEXT_FILE}"
-}
-
 cookiecutter_cache_dir() {
-  local template_url=$1
-  local repo_name=""
-
-  if [[ "${template_url}" =~ github\.com[:/][^/]+/([^/.]+)(\.git)?/?$ ]]; then
-    repo_name="${BASH_REMATCH[1]}"
-  elif [[ "${template_url}" =~ ^git@github\.com:[^/]+/([^/.]+)(\.git)?$ ]]; then
-    repo_name="${BASH_REMATCH[1]}"
+  local url=$1 name=""
+  if [[ "${url}" =~ github\.com[:/][^/]+/([^/.]+) ]]; then
+    name="${BASH_REMATCH[1]}"
+  elif [[ "${url}" =~ ^git@github\.com:[^/]+/([^/.]+) ]]; then
+    name="${BASH_REMATCH[1]}"
   else
     return 1
   fi
-
-  echo "${HOME}/.cookiecutters/${repo_name}"
+  printf '%s\n' "${HOME}/.cookiecutters/${name}"
 }
 
 refresh_template_cache() {
-  local template_url=$1
-  local upgrade_branch=$2
-  local cache_dir=""
-
-  if ! cache_dir="$(cookiecutter_cache_dir "${template_url}")"; then
-    echo "warning: could not derive cookiecutter cache dir from template URL: ${template_url}" >&2
+  local url=$1 branch=$2 cache=""
+  cache="$(cookiecutter_cache_dir "${url}")" || {
+    echo "warning: could not derive cookiecutter cache dir from: ${url}" >&2
+    return 0
+  }
+  if [ ! -d "${cache}/.git" ]; then
+    echo "cookiecutter cache not present at ${cache}; clone on bake" >&2
     return 0
   fi
-
-  if [ ! -d "${cache_dir}/.git" ]; then
-    echo "cookiecutter cache not present yet at ${cache_dir}; cookiecutter will clone on bake" >&2
-    return 0
-  fi
-
-  echo "Refreshing cookiecutter template cache ${cache_dir} @ ${upgrade_branch}"
-  git -C "${cache_dir}" fetch origin "${upgrade_branch}"
-  git -C "${cache_dir}" checkout "${upgrade_branch}"
-  git -C "${cache_dir}" merge --ff-only "origin/${upgrade_branch}"
+  echo "Refreshing cookiecutter cache ${cache} @ ${branch}"
+  git -C "${cache}" fetch origin "${branch}"
+  git -C "${cache}" checkout "${branch}"
+  git -C "${cache}" merge --ff-only "origin/${branch}"
 }
 
 resolve_template_parent_sha() {
-  local template_url=$1
-  local upgrade_branch=$2
-
-  if git remote get-url cookiecutter-upstream >/dev/null 2>&1; then
-    git fetch cookiecutter-upstream "${upgrade_branch}"
-    git rev-parse "cookiecutter-upstream/${upgrade_branch}"
+  local url=$1 branch=$2 cache=""
+  if git remote get-url cookiecutter-upstream &>/dev/null; then
+    git fetch cookiecutter-upstream "${branch}"
+    git rev-parse "cookiecutter-upstream/${branch}"
     return 0
   fi
-
-  local cache_dir=""
-  if cache_dir="$(cookiecutter_cache_dir "${template_url}")" && [ -d "${cache_dir}/.git" ]; then
-    git -C "${cache_dir}" rev-parse "origin/${upgrade_branch}"
+  if cache="$(cookiecutter_cache_dir "${url}")" && [ -d "${cache}/.git" ]; then
+    git -C "${cache}" rev-parse "origin/${branch}"
     return 0
   fi
-
-  git fetch origin "${upgrade_branch}"
-  git rev-parse "origin/${upgrade_branch}"
+  git fetch origin "${branch}"
+  git rev-parse "origin/${branch}"
 }
 
 read_template_parent_stamp() {
-  if git rev-parse --verify "${TEMPLATE_BRANCH}" >/dev/null 2>&1; then
-    git show "${TEMPLATE_BRANCH}:${TEMPLATE_PARENT_SHA_FILE}" 2>/dev/null | tr -d '[:space:]' || true
-  fi
+  git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null \
+    || return 0
+  git show "${TEMPLATE_BRANCH}:${STAMP_FILE}" 2>/dev/null | tr -d '[:space:]' || true
 }
 
 stamp_template_parent_sha() {
-  local parent_sha=$1
-  local stamp_worktree=""
+  local parent_sha=$1 wt=""
+  wt="$(mktemp -d)"
+  trap 'git worktree remove --force "${wt}" &>/dev/null; rm -rf "${wt}"' RETURN
 
-  stamp_worktree="$(mktemp -d)"
-  cleanup_stamp_worktree() {
-    git worktree remove --force "${stamp_worktree}" >/dev/null 2>&1 || true
-    rm -rf "${stamp_worktree}"
-  }
-  trap cleanup_stamp_worktree RETURN
-
-  git worktree add --detach "${stamp_worktree}" "${TEMPLATE_BRANCH}"
-  mkdir -p "${stamp_worktree}/.make"
-  printf '%s\n' "${parent_sha}" > "${stamp_worktree}/${TEMPLATE_PARENT_SHA_FILE}"
-  if git -C "${stamp_worktree}" diff --quiet -- "${TEMPLATE_PARENT_SHA_FILE}"; then
-    echo "template-parent-sha already recorded on ${TEMPLATE_BRANCH}"
+  git worktree add --detach "${wt}" "${TEMPLATE_BRANCH}"
+  mkdir -p "${wt}/${MAKE_DIR}"
+  printf '%s\n' "${parent_sha}" > "${wt}/${STAMP_FILE}"
+  if git -C "${wt}" diff --quiet -- "${STAMP_FILE}"; then
+    echo "template-parent-sha already on ${TEMPLATE_BRANCH}"
     return 0
   fi
-  git -C "${stamp_worktree}" add "${TEMPLATE_PARENT_SHA_FILE}"
-  git -C "${stamp_worktree}" commit -m "Record template parent SHA ${parent_sha:0:12}"
+  git -C "${wt}" add "${STAMP_FILE}"
+  git -C "${wt}" commit -m "Record template parent SHA ${parent_sha:0:12}"
   git push origin "HEAD:${TEMPLATE_BRANCH}"
 }
 
 verify_template_branch_freshness() {
-  local parent_sha=$1
-  local tip_before=$2
-  local tip_after=$3
-  local stamp=""
-
+  local parent_sha=$1 tip_before=$2 tip_after=$3 stamp=""
   stamp="$(read_template_parent_stamp)"
+
   if [ "${tip_before}" != "${tip_after}" ]; then
-    if [ "${stamp}" != "${parent_sha}" ]; then
-      stamp_template_parent_sha "${parent_sha}"
-    fi
-    echo "Re-baked ${TEMPLATE_BRANCH}: ${tip_before:0:12} -> ${tip_after:0:12} @ parent ${parent_sha:0:12}"
+    [ "${stamp}" != "${parent_sha}" ] && stamp_template_parent_sha "${parent_sha}"
+    echo "Re-baked ${TEMPLATE_BRANCH}: ${tip_before:0:12} -> ${tip_after:0:12} @ ${parent_sha:0:12}"
     return 0
   fi
-
   if [ "${stamp}" = "${parent_sha}" ]; then
-    echo "Template branch already matches parent ${parent_sha:0:12}; continuing idempotently"
+    echo "Template branch matches parent ${parent_sha:0:12}; idempotent"
     return 0
   fi
 
-  >&2 echo "error: ${TEMPLATE_BRANCH} tip unchanged (${tip_after:0:12}) but parent is ${parent_sha:0:12}"
-  >&2 echo "       recorded stamp: ${stamp:-<missing>}"
-  >&2 echo "       Refresh failed or bake used stale template cache; fix cache/upstream and retry."
+  >&2 cat <<EOF
+error: ${TEMPLATE_BRANCH} tip unchanged (${tip_after:0:12}) but parent is ${parent_sha:0:12}
+       recorded stamp: ${stamp:-<missing>}
+       Refresh failed or bake used stale cache; fix upstream/cache and retry.
+EOF
   exit 1
 }
 
-if [ -f "${MAIN_REPO_ROOT}/rbs_collection.yaml" ]; then
-  mv "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
-  touch "${MAKE_DIR}/rbs_collection_yaml_hidden"
-  RBS_HIDDEN=1
-fi
-if [ -f "${MAIN_REPO_ROOT}/.rubocop.yml" ]; then
-  mv "${MAIN_REPO_ROOT}/.rubocop.yml" "${MAKE_DIR}/rubocop-main.yml.bak"
-  touch "${MAKE_DIR}/rubocop_main_hidden"
-  RUBOCOP_MAIN_HIDDEN=1
-fi
-# Nested tiers may have their own .rubocop.yml; hide it so RuboCop does not inherit
-# mismatched config while cookiecutter_project_upgrader runs under .git/cookiecutter/
-if [ -f "${REPO_CWD}/.rubocop.yml" ]; then
-  mv "${REPO_CWD}/.rubocop.yml" "${MAKE_DIR}/rubocop-cwd.yml.bak"
-  touch "${MAKE_DIR}/rubocop_cwd_hidden"
-  RUBOCOP_CWD_HIDDEN=1
-fi
+hide_for_bake "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
+hide_for_bake "${MAIN_REPO_ROOT}/.rubocop.yml" "${MAKE_DIR}/rubocop-main.yml.bak"
+hide_for_bake "${REPO_CWD}/.rubocop.yml" "${MAKE_DIR}/rubocop-cwd.yml.bak"
 
-if [ -f .make/git-worktree-pointer ] && [ ! -f .git ] && [ ! -L .git ]; then
-  echo "error: stale ${MAKE_DIR}/git-worktree-pointer but .git is missing; restore manually" >&2
+if [ -f .make/git-worktree-pointer ] && [ ! -e .git ]; then
+  echo "error: stale ${MAKE_DIR}/git-worktree-pointer but .git missing" >&2
   exit 1
 fi
 
@@ -203,55 +164,47 @@ elif [ -f .git ] && [ ! -L .git ]; then
   exit 1
 fi
 
-TEMPLATE_URL=""
-if [ -f "${CONTEXT_FILE}" ]; then
-  TEMPLATE_URL="$(template_url_from_context)"
-fi
-if [ -n "${TEMPLATE_URL}" ]; then
-  refresh_template_cache "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}"
-fi
+[ -n "${TEMPLATE_URL}" ] && refresh_template_cache "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}"
 PARENT_SHA="$(resolve_template_parent_sha "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}")"
 echo "Template parent SHA (${TEMPLATE_UPGRADE_BRANCH}): ${PARENT_SHA}"
 
-if git rev-parse --verify "${TEMPLATE_BRANCH}" >/dev/null 2>&1; then
+TEMPLATE_TIP_BEFORE=""
+if git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null; then
   TEMPLATE_TIP_BEFORE="$(git rev-parse "${TEMPLATE_BRANCH}")"
-else
-  TEMPLATE_TIP_BEFORE=""
 fi
 
 export IN_COOKIECUTTER_PROJECT_UPGRADER=1
 UPGRADER_ARGS=(-p true -u "${TEMPLATE_UPGRADE_BRANCH}")
-if [ -f "${CONTEXT_FILE}" ]; then
-  UPGRADER_ARGS=(-c "${CONTEXT_FILE}" "${UPGRADER_ARGS[@]}")
-fi
+[ -f "${CONTEXT_FILE}" ] && UPGRADER_ARGS=(-c "${CONTEXT_FILE}" "${UPGRADER_ARGS[@]}")
 if ! cookiecutter_project_upgrader "${UPGRADER_ARGS[@]}"; then
-  if [ -z "${TEMPLATE_TIP_BEFORE}" ] || ! git rev-parse --verify "${TEMPLATE_BRANCH}" >/dev/null 2>&1; then
-    >&2 echo "error: cookiecutter_project_upgrader failed and ${TEMPLATE_BRANCH} is missing"
+  if [ -z "${TEMPLATE_TIP_BEFORE}" ] \
+    || ! git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null; then
+    >&2 echo "error: upgrader failed and ${TEMPLATE_BRANCH} is missing"
     exit 1
   fi
   echo "cookiecutter_project_upgrader reported no template diff; checking parent SHA stamp"
 fi
 
-TEMPLATE_TIP_AFTER="$(git rev-parse "${TEMPLATE_BRANCH}")"
-verify_template_branch_freshness "${PARENT_SHA}" "${TEMPLATE_TIP_BEFORE}" "${TEMPLATE_TIP_AFTER}"
+verify_template_branch_freshness "${PARENT_SHA}" "${TEMPLATE_TIP_BEFORE}" \
+  "$(git rev-parse "${TEMPLATE_BRANCH}")"
 
 trap - EXIT
 cleanup_prepare
 
-# Finish phase (worktree-safe: no checkout of branches locked in other worktrees)
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
-if git symbolic-ref -q "refs/remotes/origin/HEAD" >/dev/null 2>&1; then
+if git symbolic-ref -q refs/remotes/origin/HEAD &>/dev/null; then
   DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')"
 fi
 
-if ! git diff --quiet -- Makefile 2>/dev/null || ! git diff --cached --quiet -- Makefile 2>/dev/null; then
+if ! git diff --quiet -- Makefile 2>/dev/null \
+  || ! git diff --cached --quiet -- Makefile 2>/dev/null; then
   git stash push -m 'update_from_cookiecutter Makefile' -- Makefile
   touch "${MAKE_DIR}/cookiecutter_makefile_stashed"
 fi
 
 git push --no-verify origin "${TEMPLATE_BRANCH}"
+git fetch origin "${DEFAULT_BRANCH}"
 
-git fetch "origin" "${DEFAULT_BRANCH}"
 UPDATE_BRANCH="update-from-cookiecutter-$(date +%Y-%m-%d-%H%M)"
 git switch -c "${UPDATE_BRANCH}" "origin/${DEFAULT_BRANCH}"
 echo "Created branch ${UPDATE_BRANCH} from origin/${DEFAULT_BRANCH}"
@@ -272,8 +225,10 @@ bundle update --conservative json rexml || true
 ( make build && git add Gemfile.lock ) || true
 bin/overcommit --install || true
 
-echo
-echo "Please resolve any merge conflicts below and push up a PR with:"
-echo
-echo '   gh pr create --title "Update from upstream" --body "Automated PR to update from upstream boilerplate"'
-echo
+cat <<'EOF'
+
+Please resolve any merge conflicts below and push up a PR with:
+
+   gh pr create --title "Update from upstream" --body "Automated PR to update from upstream boilerplate"
+
+EOF

--- a/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
+++ b/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
@@ -125,7 +125,7 @@ stamp_template_parent_sha() {
   local parent_sha=$1
   local stamp_worktree=""
 
-  stamp_worktree="$(mktemp -d "${TMPDIR:-/tmp}/cookiecutter-template-stamp.XXXXXX")"
+  stamp_worktree="$(mktemp -d)"
   cleanup_stamp_worktree() {
     git worktree remove --force "${stamp_worktree}" >/dev/null 2>&1 || true
     rm -rf "${stamp_worktree}"

--- a/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
+++ b/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
@@ -69,35 +69,38 @@ cookiecutter_cache_dir() {
   printf '%s\n' "${HOME}/.cookiecutters/${name}"
 }
 
-refresh_template_cache() {
-  local url=$1 branch=$2 cache=""
-  cache="$(cookiecutter_cache_dir "${url}")" || {
-    echo "warning: could not derive cookiecutter cache dir from: ${url}" >&2
-    return 0
-  }
-  if [ ! -d "${cache}/.git" ]; then
-    echo "cookiecutter cache not present at ${cache}; clone on bake" >&2
-    return 0
+wipe_template_cache() {
+  local url=$1 cache=""
+  cache="$(cookiecutter_cache_dir "${url}")" || return 0
+  if [ -e "${cache}" ]; then
+    echo "Removing cookiecutter cache ${cache}"
+    rm -rf "${cache}"
   fi
-  echo "Refreshing cookiecutter cache ${cache} @ ${branch}"
-  git -C "${cache}" fetch origin "${branch}"
-  git -C "${cache}" checkout "${branch}"
-  git -C "${cache}" merge --ff-only "origin/${branch}"
 }
 
 resolve_template_parent_sha() {
-  local url=$1 branch=$2 cache=""
+  local url=$1 branch=$2 cache="" sha=""
   if git remote get-url cookiecutter-upstream &>/dev/null; then
     git fetch cookiecutter-upstream "${branch}"
     git rev-parse "cookiecutter-upstream/${branch}"
     return 0
   fi
   if cache="$(cookiecutter_cache_dir "${url}")" && [ -d "${cache}/.git" ]; then
-    git -C "${cache}" rev-parse "origin/${branch}"
+    git -C "${cache}" rev-parse "${branch}" 2>/dev/null \
+      || git -C "${cache}" rev-parse "origin/${branch}"
     return 0
   fi
-  git fetch origin "${branch}"
-  git rev-parse "origin/${branch}"
+  if [ -n "${url}" ]; then
+    sha="$(git ls-remote "${url}" "refs/heads/${branch}" | awk 'NR==1 { print $1; exit }')"
+    [ -n "${sha}" ] || {
+      echo "error: could not resolve parent SHA for ${url} @ ${branch}" >&2
+      return 1
+    }
+    printf '%s\n' "${sha}"
+    return 0
+  fi
+  echo "error: no template URL or cookiecutter-upstream for parent SHA" >&2
+  return 1
 }
 
 read_template_parent_stamp() {
@@ -140,7 +143,7 @@ verify_template_branch_freshness() {
   >&2 cat <<EOF
 error: ${TEMPLATE_BRANCH} tip unchanged (${tip_after:0:12}) but parent is ${parent_sha:0:12}
        recorded stamp: ${stamp:-<missing>}
-       Refresh failed or bake used stale cache; fix upstream/cache and retry.
+       Wipe cache and retry, or check cookiecutter-upstream / template URL.
 EOF
   exit 1
 }
@@ -164,9 +167,7 @@ elif [ -f .git ] && [ ! -L .git ]; then
   exit 1
 fi
 
-[ -n "${TEMPLATE_URL}" ] && refresh_template_cache "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}"
-PARENT_SHA="$(resolve_template_parent_sha "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}")"
-echo "Template parent SHA (${TEMPLATE_UPGRADE_BRANCH}): ${PARENT_SHA}"
+[ -n "${TEMPLATE_URL}" ] && wipe_template_cache "${TEMPLATE_URL}"
 
 TEMPLATE_TIP_BEFORE=""
 if git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null; then
@@ -184,6 +185,9 @@ if ! cookiecutter_project_upgrader "${UPGRADER_ARGS[@]}"; then
   fi
   echo "cookiecutter_project_upgrader reported no template diff; checking parent SHA stamp"
 fi
+
+PARENT_SHA="$(resolve_template_parent_sha "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}")"
+echo "Template parent SHA (${TEMPLATE_UPGRADE_BRANCH}): ${PARENT_SHA}"
 
 verify_template_branch_freshness "${PARENT_SHA}" "${TEMPLATE_TIP_BEFORE}" \
   "$(git rev-parse "${TEMPLATE_BRANCH}")"

--- a/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
+++ b/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
@@ -103,12 +103,6 @@ resolve_template_parent_sha() {
   return 1
 }
 
-read_template_parent_stamp() {
-  git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null \
-    || return 0
-  git show "${TEMPLATE_BRANCH}:${STAMP_FILE}" 2>/dev/null | tr -d '[:space:]' || true
-}
-
 stamp_template_parent_sha() {
   local parent_sha=$1 wt=""
   wt="$(mktemp -d)"
@@ -124,28 +118,6 @@ stamp_template_parent_sha() {
   git -C "${wt}" add "${STAMP_FILE}"
   git -C "${wt}" commit -m "Record template parent SHA ${parent_sha:0:12}"
   git push origin "HEAD:${TEMPLATE_BRANCH}"
-}
-
-verify_template_branch_freshness() {
-  local parent_sha=$1 tip_before=$2 tip_after=$3 stamp=""
-  stamp="$(read_template_parent_stamp)"
-
-  if [ "${tip_before}" != "${tip_after}" ]; then
-    [ "${stamp}" != "${parent_sha}" ] && stamp_template_parent_sha "${parent_sha}"
-    echo "Re-baked ${TEMPLATE_BRANCH}: ${tip_before:0:12} -> ${tip_after:0:12} @ ${parent_sha:0:12}"
-    return 0
-  fi
-  if [ "${stamp}" = "${parent_sha}" ]; then
-    echo "Template branch matches parent ${parent_sha:0:12}; idempotent"
-    return 0
-  fi
-
-  >&2 cat <<EOF
-error: ${TEMPLATE_BRANCH} tip unchanged (${tip_after:0:12}) but parent is ${parent_sha:0:12}
-       recorded stamp: ${stamp:-<missing>}
-       Wipe cache and retry, or check cookiecutter-upstream / template URL.
-EOF
-  exit 1
 }
 
 hide_for_bake "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
@@ -169,28 +141,20 @@ fi
 
 [ -n "${TEMPLATE_URL}" ] && wipe_template_cache "${TEMPLATE_URL}"
 
-TEMPLATE_TIP_BEFORE=""
-if git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null; then
-  TEMPLATE_TIP_BEFORE="$(git rev-parse "${TEMPLATE_BRANCH}")"
-fi
-
 export IN_COOKIECUTTER_PROJECT_UPGRADER=1
 UPGRADER_ARGS=(-p true -u "${TEMPLATE_UPGRADE_BRANCH}")
 [ -f "${CONTEXT_FILE}" ] && UPGRADER_ARGS=(-c "${CONTEXT_FILE}" "${UPGRADER_ARGS[@]}")
 if ! cookiecutter_project_upgrader "${UPGRADER_ARGS[@]}"; then
-  if [ -z "${TEMPLATE_TIP_BEFORE}" ] \
-    || ! git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null; then
+  if ! git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null; then
     >&2 echo "error: upgrader failed and ${TEMPLATE_BRANCH} is missing"
     exit 1
   fi
-  echo "cookiecutter_project_upgrader reported no template diff; checking parent SHA stamp"
+  echo "cookiecutter_project_upgrader reported no template diff"
 fi
 
 PARENT_SHA="$(resolve_template_parent_sha "${TEMPLATE_URL}" "${TEMPLATE_UPGRADE_BRANCH}")"
 echo "Template parent SHA (${TEMPLATE_UPGRADE_BRANCH}): ${PARENT_SHA}"
-
-verify_template_branch_freshness "${PARENT_SHA}" "${TEMPLATE_TIP_BEFORE}" \
-  "$(git rev-parse "${TEMPLATE_BRANCH}")"
+stamp_template_parent_sha "${PARENT_SHA}"
 
 trap - EXIT
 cleanup_prepare


### PR DESCRIPTION
## Summary
- Refresh cookiecutter template cache and pass `-u main` before each bake
- Record `.make/template-parent-sha` on `cookiecutter-template` after a successful re-bake
- Allow idempotent runs only when the stamp matches current parent main (or cookiecutter-upstream/main)
- Fail loudly when template tip is unchanged but parent moved (stale cache / stale branch)
- Stop swallowing template push and merge failures

Fixes the class of bug where an old cookiecutter-template reformat was merged weeks later without re-baking from current parent (pypackage stale SKILL carriage).

## Test plan
- [x] bin/test_git_worktree_upgrader.sh
- [ ] CI green
- [ ] After merge: restart upstream cascade so child syncs pick up the gate