### PR TITLE
Fix bash 3.2 crash in upgrader cleanup

### DIFF
--- a/bin/cookiecutter_project_upgrader.sh
+++ b/bin/cookiecutter_project_upgrader.sh
@@ -15,18 +15,20 @@ TEMPLATE_UPGRADE_BRANCH="${COOKIECUTTER_TEMPLATE_UPGRADE_BRANCH:-main}"
 GIT_WORKTREE_SHIM=0
 REPO_CWD="$(pwd)"
 HIDDEN_BACKUPS=()
+HIDDEN_BACKUP_COUNT=0
 
 hide_for_bake() {
   local src=$1 bak=$2
   if [ -f "${src}" ]; then
     mv "${src}" "${bak}"
     HIDDEN_BACKUPS+=("${bak}|${src}")
+    HIDDEN_BACKUP_COUNT=$((HIDDEN_BACKUP_COUNT + 1))
   fi
 }
 
 restore_hidden() {
   local entry bak dest
-  if [ ${#HIDDEN_BACKUPS[@]} -eq 0 ]; then
+  if [ "${HIDDEN_BACKUP_COUNT}" -eq 0 ]; then
     return 0
   fi
   for entry in "${HIDDEN_BACKUPS[@]}"; do
@@ -35,6 +37,7 @@ restore_hidden() {
     [ -f "${bak}" ] && mv "${bak}" "${dest}"
   done
   HIDDEN_BACKUPS=()
+  HIDDEN_BACKUP_COUNT=0
 }
 
 cleanup_prepare() {

--- a/bin/cookiecutter_project_upgrader.sh
+++ b/bin/cookiecutter_project_upgrader.sh
@@ -26,6 +26,9 @@ hide_for_bake() {
 
 restore_hidden() {
   local entry bak dest
+  if [ ${#HIDDEN_BACKUPS[@]} -eq 0 ]; then
+    return 0
+  fi
   for entry in "${HIDDEN_BACKUPS[@]}"; do
     bak="${entry%%|*}"
     dest="${entry#*|}"

--- a/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
+++ b/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
@@ -15,18 +15,20 @@ TEMPLATE_UPGRADE_BRANCH="${COOKIECUTTER_TEMPLATE_UPGRADE_BRANCH:-main}"
 GIT_WORKTREE_SHIM=0
 REPO_CWD="$(pwd)"
 HIDDEN_BACKUPS=()
+HIDDEN_BACKUP_COUNT=0
 
 hide_for_bake() {
   local src=$1 bak=$2
   if [ -f "${src}" ]; then
     mv "${src}" "${bak}"
     HIDDEN_BACKUPS+=("${bak}|${src}")
+    HIDDEN_BACKUP_COUNT=$((HIDDEN_BACKUP_COUNT + 1))
   fi
 }
 
 restore_hidden() {
   local entry bak dest
-  if [ ${#HIDDEN_BACKUPS[@]} -eq 0 ]; then
+  if [ "${HIDDEN_BACKUP_COUNT}" -eq 0 ]; then
     return 0
   fi
   for entry in "${HIDDEN_BACKUPS[@]}"; do
@@ -35,6 +37,7 @@ restore_hidden() {
     [ -f "${bak}" ] && mv "${bak}" "${dest}"
   done
   HIDDEN_BACKUPS=()
+  HIDDEN_BACKUP_COUNT=0
 }
 
 cleanup_prepare() {

--- a/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
+++ b/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
@@ -26,6 +26,9 @@ hide_for_bake() {
 
 restore_hidden() {
   local entry bak dest
+  if [ ${#HIDDEN_BACKUPS[@]} -eq 0 ]; then
+    return 0
+  fi
   for entry in "${HIDDEN_BACKUPS[@]}"; do
     bak="${entry%%|*}"
     dest="${entry#*|}"


### PR DESCRIPTION
## Summary
- Guard `restore_hidden` when `HIDDEN_BACKUPS` is empty — bash 3.2 + `set -u` treats `"${HIDDEN_BACKUPS[@]}"` as unbound on macOS.
- Found during pypackage canary run of #626 cache-wipe path after a no-diff bake.

## Test plan
- [x] `bin/test_git_worktree_upgrader.sh`
- [x] Canary: `make update_from_cookiecutter` on cookiecutter-pypackage reaches finish phase past no-diff cleanup