### PR TITLE
Require direnv for post-checkout fix.sh bootstrap

### DIFF
--- a/bin/git-post-checkout-fix
+++ b/bin/git-post-checkout-fix
@@ -13,8 +13,20 @@ if [ "${branch_checkout}" != '1' ] || [ "${prev_head}" != "${NULL_REF}" ]; then
   exit 0
 fi
 
-# fix.sh calls bin/* helpers; .envrc (via direnv) adds bin/ to PATH.
-if [ -f .envrc ] && command -v direnv >/dev/null 2>&1; then
+# Git hooks often have a minimal PATH; include common direnv locations.
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:${HOME}/.rbenv/bin:${HOME}/.local/bin:${PATH}"
+
+# fix.sh calls bin/* helpers; .envrc (via direnv) puts bin/ on PATH.
+# Never run bare ./fix.sh when .envrc exists — that skips PATH_add bin.
+if [ -f .envrc ]; then
+  if ! command -v direnv >/dev/null 2>&1; then
+    echo "git-post-checkout-fix: direnv not found; cannot bootstrap with .envrc" >&2
+    exit 1
+  fi
+  if ! direnv allow .; then
+    echo "git-post-checkout-fix: direnv allow failed" >&2
+    exit 1
+  fi
   exec direnv exec . ./fix.sh
 fi
 

--- a/{{cookiecutter.project_slug}}/bin/git-post-checkout-fix
+++ b/{{cookiecutter.project_slug}}/bin/git-post-checkout-fix
@@ -13,8 +13,20 @@ if [ "${branch_checkout}" != '1' ] || [ "${prev_head}" != "${NULL_REF}" ]; then
   exit 0
 fi
 
-# fix.sh calls bin/* helpers; .envrc (via direnv) adds bin/ to PATH.
-if [ -f .envrc ] && command -v direnv >/dev/null 2>&1; then
+# Git hooks often have a minimal PATH; include common direnv locations.
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:${HOME}/.rbenv/bin:${HOME}/.local/bin:${PATH}"
+
+# fix.sh calls bin/* helpers; .envrc (via direnv) puts bin/ on PATH.
+# Never run bare ./fix.sh when .envrc exists — that skips PATH_add bin.
+if [ -f .envrc ]; then
+  if ! command -v direnv >/dev/null 2>&1; then
+    echo "git-post-checkout-fix: direnv not found; cannot bootstrap with .envrc" >&2
+    exit 1
+  fi
+  if ! direnv allow .; then
+    echo "git-post-checkout-fix: direnv allow failed" >&2
+    exit 1
+  fi
   exec direnv exec . ./fix.sh
 fi
 

--- a/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/bin/git-post-checkout-fix
+++ b/{{cookiecutter.project_slug}}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}/bin/git-post-checkout-fix
@@ -13,8 +13,20 @@ if [ "${branch_checkout}" != '1' ] || [ "${prev_head}" != "${NULL_REF}" ]; then
   exit 0
 fi
 
-# fix.sh calls bin/* helpers; .envrc (via direnv) adds bin/ to PATH.
-if [ -f .envrc ] && command -v direnv >/dev/null 2>&1; then
+# Git hooks often have a minimal PATH; include common direnv locations.
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:${HOME}/.rbenv/bin:${HOME}/.local/bin:${PATH}"
+
+# fix.sh calls bin/* helpers; .envrc (via direnv) puts bin/ on PATH.
+# Never run bare ./fix.sh when .envrc exists — that skips PATH_add bin.
+if [ -f .envrc ]; then
+  if ! command -v direnv >/dev/null 2>&1; then
+    echo "git-post-checkout-fix: direnv not found; cannot bootstrap with .envrc" >&2
+    exit 1
+  fi
+  if ! direnv allow .; then
+    echo "git-post-checkout-fix: direnv allow failed" >&2
+    exit 1
+  fi
   exec direnv exec . ./fix.sh
 fi
 


### PR DESCRIPTION
## Summary
- When `.envrc` is present, `bin/git-post-checkout-fix` always runs `direnv allow` + `direnv exec . ./fix.sh` instead of falling back to bare `./fix.sh`.
- Puts common Homebrew/`direnv` paths on `PATH` first so git hooks can find `direnv`.
- Fixes fresh worktree bootstrap failures (`ensure_package: command not found`) caused by skipping `.envrc` `PATH_add bin`.

## Test plan
- [ ] `git worktree add` from a checkout that uses `.githooks` / this script and confirm post-checkout runs under direnv
- [ ] Confirm a fresh worktree with no vendored rugged can resolve `bin/ensure_package` during `./fix.sh`
- [ ] Confirm repos without `.envrc` still fall through to bare `./fix.sh`